### PR TITLE
Added Travis CI file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+dist: xenial
+addons:
+  apt:
+    packages:
+      - libyaml-dev
+
+branches:
+  only:
+  - master
+
+language: c
+
+compiler: gcc
+
+script:
+  - make


### PR DESCRIPTION
This addresses issue #3 

I've added a .travis.yml file and verified it works on the `master` branch of a fork of chiventure (see https://travis-ci.org/borjasotomayor/chiventure/builds/524971592)

I've also activated Travis on uchicago-cs/chiventure, but I suspect there will be additional setup once this pull request is merged.