### PR TITLE
 Updated action structs to reflect Sprint 3 Discussion (5/10)

### DIFF
--- a/src/action_management/include/actionmanagement.h
+++ b/src/action_management/include/actionmanagement.h
@@ -45,7 +45,7 @@ enum object_type {
 
 /* An action struct that contains the following: 
  * - act: the encoded enum name for this action
- * c_name - the 'canonical' string that should call the enum
+ * - c_name: the 'canonical' string that should call the enum
  * synonyms - the synonyms that would also be allowed to call action
  * parameters - an order-sensitive linked list of object_type enums
 */

--- a/src/action_management/include/actionmanagement.h
+++ b/src/action_management/include/actionmanagement.h
@@ -32,22 +32,20 @@ enum action_type {
 		"turn on", "turn off", and "go" */
   ACT_INVENTORY /* includes "take", "drop", "consume" */
 };
-  
+
+enum object
+
 
 /* An action struct that contains the following: 
  * act: A tag corresponding to the action 
  * type: A tag describing the type of action
- * num_arg: the number of actions required for the action to be valid
+ * parameters - array of enum inputs
 */
-struct action_struct {
+typedef struct {
   enum actions act;
   enum action_type type;
-  int num_arg; 
-};
-
-
-/* A type declaration of the action struct to action_t. */
-typedef struct action_struct action_t;
+  int *parameters;
+} action_t;
 
 
 /* 

--- a/src/action_management/include/actionmanagement.h
+++ b/src/action_management/include/actionmanagement.h
@@ -46,7 +46,7 @@ enum object_type {
 /* An action struct that contains the following: 
  * - act: the encoded enum name for this action
  * - c_name: the 'canonical' string that should call the enum
- * synonyms - the synonyms that would also be allowed to call action
+ * - synonyms: the synonyms that would also be allowed to call action
  * parameters - an order-sensitive linked list of object_type enums
 */
 typedef struct {

--- a/src/action_management/include/actionmanagement.h
+++ b/src/action_management/include/actionmanagement.h
@@ -47,7 +47,7 @@ enum object_type {
  * - act: the encoded enum name for this action
  * - c_name: the 'canonical' string that should call the enum
  * - synonyms: the synonyms that would also be allowed to call action
- * parameters - an order-sensitive linked list of object_type enums
+ * - parameters: an order-sensitive linked list of object_type enums
 */
 typedef struct {
 	enum actions act;   // e.g. CONSUME

--- a/src/action_management/include/actionmanagement.h
+++ b/src/action_management/include/actionmanagement.h
@@ -44,7 +44,7 @@ enum object_type {
 
 
 /* An action struct that contains the following: 
- * act - the encoded enum name for this action
+ * - act: the encoded enum name for this action
  * c_name - the 'canonical' string that should call the enum
  * synonyms - the synonyms that would also be allowed to call action
  * parameters - an order-sensitive linked list of object_type enums

--- a/src/action_management/include/actionmanagement.h
+++ b/src/action_management/include/actionmanagement.h
@@ -51,7 +51,7 @@ enum object_type {
 */
 typedef struct {
 	enum actions act;   // e.g. CONSUME
-	char *c_name; 		// e.g. "eat"
+	char *c_name;  // e.g. "eat"
 	list_t *synonyms;   // e.g. "drink" -> "use"
 	list_t *parameters; // e.g. ITEM_OBJ -> NPC_OBJ
 } action_t;


### PR DESCRIPTION
There were a number of issues that we decided on during Sprint 3 such as:

- splitting actions into "kinds", or types so that we could better manage them
- placing the synonyms and canonical names within the struct so that they could be accessed by other teams
- creating a "get_supported_actions()" function

I've added these functions to the document and would appreciate any feedback!