### PR TITLE
Hotfix: game-state build on master is broken

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ all: $(BIN)
 #  - Directory: src/ui/
 #  - Makefile: src/ui/Makefile
 #  - Library: src/ui/ui.a
-COMPONENTS = libobj ui
+COMPONENTS = libobj ui cli game-state
 LIBS = $(foreach comp,$(COMPONENTS),src/$(comp)/$(comp).a)
 
 $(LIBS):

--- a/docs/GAME-STATE.md
+++ b/docs/GAME-STATE.md
@@ -120,7 +120,7 @@ The room module provides the framework for a data representation of the physical
 - access traits of the room such as its descriptions and possible paths
 
 ## The Path Module
-The path module deals specifically with the connections among rooms. Each path struct stores a path_id, which is used to identify the direction from the starting room, a path destination, which stores the id of the ending room, and a linked list of conditions. All the path connected to each room will be stored in a hash table data structure in that specific room. Functions in the path module allow authors to:
+The path module deals specifically with the connections among rooms. Each path struct stores a direction, which is used to identify the direction from the starting room, a path destination, which stores the id of the ending room, and a linked list of conditions. All the path connected to each room will be stored in a hash table data structure in that specific room. Functions in the path module allow authors to:
 
 - create new paths
 - add paths to the struct containing all the paths or to a room

--- a/src/game-state/Makefile
+++ b/src/game-state/Makefile
@@ -4,7 +4,7 @@ RM = rm -f
 SRCS = src/game.c src/player.c src/item.c src/room.c src/path.c
 OBJS = $(SRCS:.c=.o)
 BINS = $(SRCS:.c=)
-LIB = gamestate.a
+LIB = game-state.a
 
 .PHONY: all
 all: $(LIB)

--- a/src/game-state/Makefile
+++ b/src/game-state/Makefile
@@ -4,7 +4,7 @@ RM = rm -f
 SRCS = src/game.c src/player.c src/item.c src/room.c src/path.c
 OBJS = $(SRCS:.c=.o)
 BINS = $(SRCS:.c=)
-LIB = gamestate.so
+LIB = gamestate.a
 
 .PHONY: all
 all: $(LIB)

--- a/src/game-state/include/path.h
+++ b/src/game-state/include/path.h
@@ -29,9 +29,9 @@ typedef struct condition* condition_list_t;
  * */
 typedef struct path {
     UT_hash_handle hh;
-    /* path_id means the direction (north/south/etc) */
+    /* direction (north/south/etc) */
     /* for hashtable consistency (e.g. player hash uses player_id), */
-    /* we use path_id here to avoid bugs when using uthash functions */
+    /* we use direction here to avoid bugs when using uthash functions */
     char *direction; // ***** MEANS DIRECTION *****
     char *dest; // ***** MEANS ROOM_ID *****
     condition_list_t conditions;
@@ -78,7 +78,7 @@ int path_free(path_t *path);
  * Returns:
  *  SUCCESS if successful, FAILURE if failed
  */
-int add_path_to_hash(path_hash_t all_paths, char* path_id, path_t *path);
+int add_path_to_hash(path_hash_t all_paths, char* direction, path_t *path);
 
 /* Adds a condition to the given path
  *

--- a/src/game-state/src/game.c
+++ b/src/game-state/src/game.c
@@ -1,6 +1,4 @@
 #include "game.h"
-#include "common-room.h"
-#include "common-player.h"
 
 /* see game.h */
 game_t *game_new() {

--- a/src/game-state/src/game.c
+++ b/src/game-state/src/game.c
@@ -1,4 +1,6 @@
 #include "game.h"
+// #include "common-player.h"
+// #include "common-room.h"
 
 /* see game.h */
 game_t *game_new() {

--- a/src/game-state/src/path.c
+++ b/src/game-state/src/path.c
@@ -13,33 +13,33 @@ int delete_all_conditions(condition_list_t conditions) {
 }
 
 /* See path.h */
-path_t *path_new(char *path_id) {
+path_t *path_new(char *direction) {
     path_t *path = malloc(sizeof(path_t));
-    path->path_id = malloc(MAX_ID_LEN * sizeof(char));
+    path->direction = malloc(MAX_ID_LEN * sizeof(char));
     path->conditions = NULL;
 
-    strcpy(path->path_id, path_id);
+    strcpy(path->direction, direction);
 
     return path;
 }
 
 /* See path.h */
 int path_free(path_t *path) {
-    free(path->path_id);
+    free(path->direction);
     delete_all_conditions(path->conditions);
     free(path);
     return SUCCESS;
 }
 
 /* See path.h */
-int add_path_to_hash(path_hash_t all_paths, char *path_id, path_t *path) {
+int add_path_to_hash(path_hash_t all_paths, char *direction, path_t *path) {
     path_t *s;
-    HASH_FIND_STR(all_paths, path_id, s);
+    HASH_FIND_STR(all_paths, direction, s);
     if (s != NULL) {
-        printf("FATAL: path_id already used!\n");
+        printf("FATAL: direction already used!\n");
         exit(1);
     }
-    HASH_ADD_STR(all_paths, path_id, path);
+    HASH_ADD_STR(all_paths, direction, path);
     return SUCCESS;
 }
 

--- a/src/game-state/src/room.c
+++ b/src/game-state/src/room.c
@@ -44,7 +44,7 @@ int add_item_to_room(room_t *room, item_t *item) {
 
 /* See room.h */
 int add_path_to_room(room_t *room, path_t *path) {
-    return add_path_to_hash(room->paths, path->path_id, path);
+    return add_path_to_hash(room->paths, path->direction, path);
 }
 
 /* See common.h */


### PR DESCRIPTION
game-state's build on `master` (from PR #105) is broken and needs to be fixed as soon as possible:

```
chiventure/src/game-state$ make
gcc -fPIC -Wall -Wextra -O2 -g -I./include/ -I../common/include/ -I./src/   -c -o src/game.o src/game.c
src/game.c:2:25: fatal error: common-room.h: No such file or directory
compilation terminated.
<builtin>: recipe for target 'src/game.o' failed
make: *** [src/game.o] Error 1
```