### PR TITLE
Create .gitignore for checkpointing .pb-c files

### DIFF
--- a/src/checkpointing/.gitignore
+++ b/src/checkpointing/.gitignore
@@ -1,0 +1,3 @@
+# Protobuf-c generated files
+*.pb-c.*
+


### PR DESCRIPTION
Created .gitignore to include .pb-c files, as per Mark's request. 