### PR TITLE
Added context type to encapsulate shared state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 CC = gcc
 AR = ar 
-CFLAGS = -fPIC -Wall -Wextra -O2 -g -I./include/
+CFLAGS = -fPIC -Wall -Wextra -O2 -g -I./include/ -I./src/common/include -I./src/game-state/include
 RM = rm -f
 LDLIBS = -lyaml
 BIN = chiventure
@@ -22,7 +22,7 @@ all: $(BIN)
 #  - Makefile: src/ui/Makefile
 #  - Library: src/ui/ui.a
 
-COMPONENTS = libobj ui cli game-state action_management checkpointing
+COMPONENTS = libobj ui cli game-state action_management checkpointing common
 LIBS = $(foreach comp,$(COMPONENTS),src/$(comp)/$(comp).a)
 
 $(LIBS):

--- a/src/chiventure.c
+++ b/src/chiventure.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include "ctx.h"
 
 const char *banner =
     "    ________________________________________________________________________________________\n"
@@ -17,6 +18,12 @@ const char *banner =
 
 int main(int argc, char **argv)
 {
+    chiventure_ctx_t ctx;
+
+    chiventure_ctx_init(&ctx);
+
+    /* Add calls to component-specific initializations here */
+
     printf("%s\n>", banner);
 
     getchar();

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -1,0 +1,29 @@
+# Makefile based on template at https://gist.github.com/xuhdev/1873316
+
+CC = gcc
+AR = ar 
+CFLAGS = -fPIC -Wall -Wextra -O2 -g -I./include/ -I../game-state/include/
+RM = rm -f
+LIB = common.a
+LDLIBS =
+
+.PHONY: all clean
+
+all: $(LIB)
+
+# Library
+
+SRCS = src/ctx.c
+OBJS = $(SRCS:.c=.o)
+
+$(SRCS:.c=.d):%.d:%.c
+	$(CC) $(CFLAGS) -MM $< -MT $(patsubst %.d,%.o,$@) > $@
+
+-include $(SRCS:.c=.d)
+
+$(LIB): $(OBJS)
+	$(AR) -r -o $@ $^
+
+clean:
+	-${RM} ${LIB} ${OBJS} $(SRCS:.c=.d)
+

--- a/src/common/include/ctx.h
+++ b/src/common/include/ctx.h
@@ -1,0 +1,56 @@
+/*
+ * Defines a context struct to store shared state
+ */
+
+#ifndef CHIVENTURE_CHIVENTURE_H
+#define CHIVENTURE_CHIVENTURE_H
+
+#include "common.h"
+#include "game.h"
+
+
+/* A context struct encapsulating all the shared state in chiventure */
+typedef struct chiventure_ctx
+{
+    /* Add component-specific structs here */
+
+    game_t *game;
+} chiventure_ctx_t;
+
+
+/*
+ * Allocates and initializes a new chiventure context.
+ *
+ * Parameters:
+ *  - None
+ *
+ * Returns:
+ *  - A pointer to the context, or NULL if it cannot be allocated
+ */
+chiventure_ctx_t* chiventure_ctx_new();
+
+
+/*
+ * Initializes a chiventure context.
+ *
+ * Parameters:
+ *  - ctx: A chiventure context. Must already point to allocated memory
+ *
+ * Returns:
+ *  - 0 on success, 1 if an error occurs.
+ */
+int chiventure_ctx_init(chiventure_ctx_t *ctx);
+
+
+/*
+ * Frees a chiventure context.
+ *
+ * Parameters:
+ *  - ctx: A heap-allocated chiventure context.
+ *
+ * Returns:
+ *  - Always returns 0.
+ */
+int chiventure_ctx_free(chiventure_ctx_t *ctx);
+
+#endif //CHIVENTURE_CHIVENTURE_H

--- a/src/common/src/ctx.c
+++ b/src/common/src/ctx.c
@@ -1,0 +1,46 @@
+#include <stdlib.h>
+#include "ctx.h"
+
+/* See ctx.h */
+chiventure_ctx_t* chiventure_ctx_new()
+{
+    chiventure_ctx_t *ctx;
+    int rc;
+
+    ctx = malloc(sizeof(chiventure_ctx_t));
+
+    if(ctx == NULL)
+    {
+        return NULL;
+    }
+
+    rc = chiventure_ctx_init(ctx);
+    if(rc != SUCCESS)
+    {
+        return NULL;
+    }
+
+    return ctx;
+}
+
+/* See ctx.h */
+int chiventure_ctx_init(chiventure_ctx_t *ctx)
+{
+    assert(ctx != NULL);
+
+    /* Add calls to component-specific initialization here */
+
+    return SUCCESS;
+}
+
+/* See ctx.h */
+int chiventure_ctx_free(chiventure_ctx_t *ctx)
+{
+    assert(ctx != NULL);
+
+    /* Add calls to component-specific freeing functions here */
+
+    free(ctx);
+
+    return SUCCESS;
+}


### PR DESCRIPTION
Added a context type that can encapsulate all the shared state in chiventure. Currently only includes the game state, but will eventually also include UI and CLI state.