### PR TITLE
Game state/action list

### DIFF
--- a/src/game-state/include/item.h
+++ b/src/game-state/include/item.h
@@ -223,7 +223,7 @@ int add_allowed_action(item_t* item, char* action_name);
  * Returns:
  *  SUCCESS if item contains action, FAILURE if it does not
  */
-int allowed_action(item* item, char* action_name);
+int allowed_action(item_t* item, char* action_name);
 
 
 #endif

--- a/src/game-state/include/item.h
+++ b/src/game-state/include/item.h
@@ -207,5 +207,23 @@ char get_char_attr(item_t *item, char* attr_name);
  */
 bool get_bool_attr(item_t *item, char* attr_name);
 
+/* add_allowed_action() adds a permitted action to an item
+ * Parameters:
+ *  a pointer to the item
+ *  the action name
+ * Returns:
+ *  SUCCESS if added correctly, FAILURE if failed to add
+ */
+int add_allowed_action(item_t* item, char* action_name);
+
+/* allowed_action() checks if an item permits a specific action
+ * Parameters:
+ *  a pointer to the item
+ *  the action name
+ * Returns:
+ *  SUCCESS if item contains action, FAILURE if it does not
+ */
+int allowed_action(item* item, char* action_name);
+
 
 #endif

--- a/src/game-state/src/item.c
+++ b/src/game-state/src/item.c
@@ -333,7 +333,7 @@ int add_allowed_action(item_t* item, char* action_name)
 }
 
 /* see item.h */
-int allowed_action(item* item, char* action_name)
+int allowed_action(item_t* item, char* action_name)
 {
     attribute_t* action = get_attribute(item, action_name);
     if (action == NULL)
@@ -342,7 +342,7 @@ int allowed_action(item* item, char* action_name)
     }
     else
     {
-        return SUCCESS:
+        return SUCCESS;
     }
 }
 

--- a/src/game-state/src/item.c
+++ b/src/game-state/src/item.c
@@ -325,6 +325,27 @@ int attributes_equal(item_t* item_1, item_t* item_2, char* attribute_name)
     return comparison;
 }
 
+/* see item.h */
+int add_allowed_action(item_t* item, char* action_name)
+{
+    int rv = set_bool_attr(item, action_name, true);
+    return rv;
+}
+
+/* see item.h */
+int allowed_action(item* item, char* action_name)
+{
+    attribute_t* action = get_attribute(item, action_name);
+    if (action == NULL)
+    {
+        return FAILURE;
+    }
+    else
+    {
+        return SUCCESS:
+    }
+}
+
 // FREEING AND DELETION FUNCTIONS ---------------------------------------------
 /* see item.h */
 int attribute_free(attribute_t *attribute) {
@@ -364,6 +385,8 @@ int delete_all_items(item_hash_t items) {
     }
     return SUCCESS;
 }
+
+
 
 /* See common-item.h */
 // int add_item_to_hash(item_t *item, char *item_id, item_t *item_toadd) {

--- a/src/game-state/tests/test_items.c
+++ b/src/game-state/tests/test_items.c
@@ -82,7 +82,7 @@ Test(attribute, add_attr_to_hash_failure)
 }
 
 
-// TEST FOR GENERAL GET_ATTRIBUTE()--------------------------------------------
+// TEST FOR GENERAL GET_ATTRIBUTE()---------------------------------------------
 
 /*Checks helper function to retrieve attribute from item*/
 Test(attribute, get_attribute)
@@ -102,7 +102,7 @@ Test(attribute, get_attribute)
 
 }
 
-// TESTS FOR TYPE-SPECIFIC SET_ATTR() FUNCTIONS -------------------------------
+// TESTS FOR TYPE-SPECIFIC SET_ATTR() FUNCTIONS --------------------------------
 
 /*Checks creation of new string attribute and adding it to an item*/
 Test(attribute, set_str_attr)
@@ -547,6 +547,49 @@ Test(attribute, not_equal_types)
 }
 
 //NEED MORE TESTS FOR COMPARISONS OF EVERY ATTR TYPE
+
+
+
+// TEST FOR ALLOWED_ACTION()----------------------------------------------------
+
+/* Checks adding an action to an item */
+Test(attribute, add_an_action)
+{
+	item_t *test_item = item_new("test_item", "action test", "item to test setting actions");
+	int rv = add_allowed_action(test_item, "push");
+	cr_assert_eq(rv, SUCCESS, "add_allowed_action: did not successfully set action");
+}
+
+/*
+Test(attribute, add_same_action)
+{
+	item_t *test_item = item_new("test_item", "action test", "item to test setting actions");
+	int rv = add_allowed_action(test_item, "push");
+	cr_assert_eq(rv, SUCCESS, "add_allowed_action: did not successfully set action");
+	rv = add_allowed_action(test_item, "push");
+	cr_assert_eq(rv, FAILURE, "add_allowed_action: added action twice");
+}
+*/
+
+/* Checks retrieving an action from an item */
+Test(attribute, get_action)
+{
+	item_t *test_item = item_new("test_item", "action test", "item to test setting actions");
+	int rv = add_allowed_action(test_item, "push");
+	cr_assert_eq(rv, SUCCESS, "add_allowed_action: did not successfully set action");
+	rv = allowed_action(test_item, "push");
+	cr_assert_eq(rv, SUCCESS, "add_allowed_action: did not retrieve action");
+}
+
+/* Checks if retrieving a nonexistent action from an item blocked*/
+Test(attribute, get_non_existent_action)
+{
+	item_t *test_item = item_new("test_item", "action test", "item to test setting actions");
+	int rv = add_allowed_action(test_item, "push");
+	cr_assert_eq(rv, SUCCESS, "add_allowed_action: did not successfully set action");
+	rv = allowed_action(test_item, "pull");
+	cr_assert_eq(rv, FAILURE, "add_allowed_action: retrieved nonexistent action");
+}
 
 // TEST FOR ATTRIBUTE_FREE() --------------------------------------------------
 

--- a/src/game-state/tests/test_items.c
+++ b/src/game-state/tests/test_items.c
@@ -560,16 +560,6 @@ Test(attribute, add_an_action)
 	cr_assert_eq(rv, SUCCESS, "add_allowed_action: did not successfully set action");
 }
 
-/*
-Test(attribute, add_same_action)
-{
-	item_t *test_item = item_new("test_item", "action test", "item to test setting actions");
-	int rv = add_allowed_action(test_item, "push");
-	cr_assert_eq(rv, SUCCESS, "add_allowed_action: did not successfully set action");
-	rv = add_allowed_action(test_item, "push");
-	cr_assert_eq(rv, FAILURE, "add_allowed_action: added action twice");
-}
-*/
 
 /* Checks retrieving an action from an item */
 Test(attribute, get_action)


### PR DESCRIPTION
This PR is to merge the work done by game-state for WDL and AM concerning an "action list" within the item struct. After conversations with both teams, it was realized that the most advantageous way to go about this is providing two function interfaces: add_allowed_action() and allowed_action(), which add an allowed action to an item and check an action's existence respectively. 

On the backend, this works by treating actions the same way we would treat a boolean attribute. 

The functions were written in item.c, interfaced through item.h, and tests written in test-item.c
