### PR TITLE
Hotfix: valid_actions to be compatible with CLI

### DIFF
--- a/src/action_management/src/get_actions.c
+++ b/src/action_management/src/get_actions.c
@@ -6,22 +6,22 @@
 
 static action_type_t valid_actions[] = {
     // KIND 1
-    {"open", ITEM},
-    {"close", ITEM},
-    {"push", ITEM},
-    {"pull", ITEM},
-    {"examine", ITEM},
-    {"turn on", ITEM},
-    {"turn off", ITEM},
-    {"take", ITEM},
-    {"drop", ITEM},
-    {"consume", ITEM},
+    {"OPEN", ITEM},
+    {"CLOSE", ITEM},
+    {"PUSH", ITEM},
+    {"PULL", ITEM},
+    {"EXAMINE", ITEM},
+    {"TURN_ON", ITEM},
+    {"TURN_OFF", ITEM},
+    {"TAKE", ITEM},
+    {"DROP", ITEM},
+    {"CONSUME", ITEM},
     // KIND 2
-    {"go", PATH},
-    {"enter", PATH},
+    {"GO", PATH},
+    {"ENTER", PATH},
     // KIND 3
-    {"use on", ITEM_ITEM},
-    {"put on", ITEM_ITEM}
+    {"USE_ON", ITEM_ITEM},
+    {"PUT_ON", ITEM_ITEM}
 };
 
 


### PR DESCRIPTION
After talking to CLI we are changing our valid_actions such that all items will be in line with our actions enum. This means we are adding capitalization and replacing spaces with underscores. This issue for this PR is #208. 