### PR TITLE
Hotfix: Changed makefile to make static library

### DIFF
--- a/src/action_management/Makefile
+++ b/src/action_management/Makefile
@@ -4,7 +4,7 @@
 
 CC = gcc
 SRCS = src/actionmanagement.c src/get_actions.c
-CFLAGS = -fPIC -Wall -Wextra -O2 -g -I./include/ -I../common/include/ -I ../game-state/include/
+CFLAGS = -fPIC -Wall -Wextra -O2 -g -I./include/ -I../common/include/ -I../game-state/include/
 LDFLAGS = -shared
 OBJS = $(SRCS:.c=.o)
 LIB = action_management.a
@@ -14,7 +14,7 @@ RM = rm -f
 all: $(LIB)
 
 $(LIB): $(OBJS)
-	$(CC) ${LDFLAGS} -o $@ $^
+	ar -r -o $@ $(OBJS)
 
 $(SRCS:.c=.d):%.d:%.c
 	$(CC) $(CFLAGS) -MM $< -MT $(patsubst %.d,%.o,$@) > $@


### PR DESCRIPTION
Currently our Makefile compiles into a dynamic library. The project specification says that it must be a static library. The goal of this issue is to make our Makefile in line with the project spec. At the request of CLI we are pushing this directly to master as a hotfix. This is the PR for #198 .