### PR TITLE
Cli/integrate with am

### DIFF
--- a/src/action_management/Makefile
+++ b/src/action_management/Makefile
@@ -4,7 +4,7 @@
 
 CC = gcc
 SRCS = src/actionmanagement.c src/get_actions.c
-CFLAGS = -fPIC -Wall -Wextra -O2 -g -I./include/ -I../common/include/ -I../game-state/include/ -I../action_management/include/
+CFLAGS = -fPIC -Wall -Wextra -O2 -g -I./include/ -I../common/include/ -I ../game-state/include/
 LDFLAGS = -shared
 OBJS = $(SRCS:.c=.o)
 LIB = action_management.a
@@ -14,7 +14,7 @@ RM = rm -f
 all: $(LIB)
 
 $(LIB): $(OBJS)
-	ar -r -o $@ $(OBJS)
+	$(CC) ${LDFLAGS} -o $@ $^
 
 $(SRCS:.c=.d):%.d:%.c
 	$(CC) $(CFLAGS) -MM $< -MT $(patsubst %.d,%.o,$@) > $@

--- a/src/action_management/Makefile
+++ b/src/action_management/Makefile
@@ -4,7 +4,7 @@
 
 CC = gcc
 SRCS = src/actionmanagement.c src/get_actions.c
-CFLAGS = -fPIC -Wall -Wextra -O2 -g -I./include/ -I../common/include/ -I ../game-state/include/
+CFLAGS = -fPIC -Wall -Wextra -O2 -g -I./include/ -I../common/include/ -I../game-state/include/ -I../action_management/include/
 LDFLAGS = -shared
 OBJS = $(SRCS:.c=.o)
 LIB = action_management.a
@@ -14,7 +14,7 @@ RM = rm -f
 all: $(LIB)
 
 $(LIB): $(OBJS)
-	$(CC) ${LDFLAGS} -o $@ $^
+	ar -r -o $@ $(OBJS)
 
 $(SRCS:.c=.d):%.d:%.c
 	$(CC) $(CFLAGS) -MM $< -MT $(patsubst %.d,%.o,$@) > $@

--- a/src/action_management/include/actionmanagement.h
+++ b/src/action_management/include/actionmanagement.h
@@ -2,9 +2,9 @@
 #define _ACTIONS_H_
 
 #include "action_structs.h"
-#include "item.h"
-#include "path.h"
-#include "game.h"
+#include "../../game-state/include/item.h"
+#include "../../game-state/include/path.h"
+#include "../../game-state/include/game.h"
 
 /* File consisting of all functions created by action management
    =========================================================================== */

--- a/src/action_management/include/actionmanagement.h
+++ b/src/action_management/include/actionmanagement.h
@@ -2,9 +2,9 @@
 #define _ACTIONS_H_
 
 #include "action_structs.h"
-#include "../../game-state/include/item.h"
-#include "../../game-state/include/path.h"
-#include "../../game-state/include/game.h"
+#include "item.h"
+#include "path.h"
+#include "game.h"
 
 /* File consisting of all functions created by action management
    =========================================================================== */

--- a/src/action_management/include/actionmanagement.h
+++ b/src/action_management/include/actionmanagement.h
@@ -62,7 +62,6 @@ void action_type_free(action_type_t *a);
  */
 list_action_type_t *get_supported_actions();
 
-
 // =============================================================================
 
 /* A function that executes KIND 1 actions (ACTION <item>)

--- a/src/cli/Makefile
+++ b/src/cli/Makefile
@@ -2,7 +2,8 @@
 
 CC = gcc
 SRCS = src/cmd.c src/shell.c src/parser.c src/operations.c src/validate.c
-CFLAGS = -fPIC -Wall -Wextra -O2 -g -I./include/ -I../common/include/ -I../game-state/include/
+CFLAGS = -fPIC -Wall -Wextra -O2 -g -I./include/ -I../common/include/ -I../game-state/include/ -I../action_management/include/
+LDFLAGS = -shared
 OBJS = $(SRCS:.c=.o)
 LIB = cli.a
 RM = rm -f
@@ -11,15 +12,12 @@ RM = rm -f
 all: $(LIB)
 
 $(LIB): $(OBJS)
-	ar -r -o $@ $(OBJS)
+	$(CC) ${LDFLAGS} -o $@ $^
 
 $(SRCS:.c=.d):%.d:%.c
 	$(CC) $(CFLAGS) -MM $< -MT $(patsubst %.d,%.o,$@) > $@
 
 -include $(SRCS:.c=.d)
-
-test: $(LIB)
-	make -C ./example
 
 .PHONY: clean
 

--- a/src/cli/Makefile
+++ b/src/cli/Makefile
@@ -3,7 +3,6 @@
 CC = gcc
 SRCS = src/cmd.c src/shell.c src/parser.c src/operations.c src/validate.c
 CFLAGS = -fPIC -Wall -Wextra -O2 -g -I./include/ -I../common/include/ -I../game-state/include/ -I../action_management/include/
-LDFLAGS = -shared
 OBJS = $(SRCS:.c=.o)
 LIB = cli.a
 RM = rm -f

--- a/src/cli/Makefile
+++ b/src/cli/Makefile
@@ -12,7 +12,7 @@ RM = rm -f
 all: $(LIB)
 
 $(LIB): $(OBJS)
-	$(CC) ${LDFLAGS} -o $@ $^
+	ar -r -o $@ $(OBJS)
 
 $(SRCS:.c=.d):%.d:%.c
 	$(CC) $(CFLAGS) -MM $< -MT $(patsubst %.d,%.o,$@) > $@

--- a/src/cli/example/Makefile
+++ b/src/cli/example/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 CFLAGS = -fPIC -Wall -Wextra -O2 -g -I../include/ -I../../common/include/ -I../../game-state/include/ -I../../action_management/include/
-LDFLAGS = -L../ -Wl,-rpath,.
+LDFLAGS = -L../ -L../../action_management/ -Wl,-rpath,../ -Wl,-rpath,../../action_management/
 RM = rm -f
 LDLIBS = -lreadline 
 
@@ -12,7 +12,7 @@ BIN = testshell
 all: ${BIN}
 
 $(BIN): $(OBJS)
-	$(CC) $(LDFLAGS) $(CFLAGS) $(OBJS) $(LDLIBS) -o$(BIN) -l:cli.a
+	$(CC) $(LDFLAGS) $(CFLAGS) $(OBJS) $(LDLIBS) -o$(BIN) -l:cli.a -l:action_management.a
 
 $(SRCS:.c=.d):%.d:%.c
 	$(CC) $(CFLAGS) -MM $< >$@

--- a/src/cli/example/Makefile
+++ b/src/cli/example/Makefile
@@ -2,6 +2,7 @@ CC = gcc
 CFLAGS = -fPIC -Wall -Wextra -O2 -g -I../include/ -I../../common/include/ -I../../game-state/include/ -I../../action_management/include/
 LDFLAGS = -L../ -Wl,-rpath,.
 RM = rm -f
+LDLIBS = -lreadline 
 
 SRCS = testshell.c
 OBJS = $(SRCS:.c=.o)
@@ -11,7 +12,7 @@ BIN = testshell
 all: ${BIN}
 
 $(BIN): $(OBJS)
-	$(CC) $(LDFLAGS) $(CFLAGS) $(OBJS) -o$(BIN) -l:cli.a -lreadline
+	$(CC) $(LDFLAGS) $(CFLAGS) $(OBJS) $(LDLIBS) -o$(BIN) -l:cli.a
 
 $(SRCS:.c=.d):%.d:%.c
 	$(CC) $(CFLAGS) -MM $< >$@

--- a/src/cli/example/Makefile
+++ b/src/cli/example/Makefile
@@ -1,18 +1,24 @@
 CC = gcc
-STC_LDFLAGS = -L../
-LIB = cli.a
+CFLAGS = -fPIC -Wall -Wextra -O2 -g -I../include/ -I../../common/include/ -I../../game-state/include/ -I../../action_management/include/
+LDFLAGS = -L../ -Wl,-rpath,.
 RM = rm -f
 
 SRCS = testshell.c
 OBJS = $(SRCS:.c=.o)
-BINS = testshell
+BIN = testshell
 
 .PHONY: all
-all: $(BINS)
+all: ${BIN}
 
-testshell: testshell.o ../cli.a 
-	$(CC) $(STC_LDFLAGS) $^ -o$@ -l:cli.a -lreadline
+$(BIN): $(OBJS)
+	$(CC) $(LDFLAGS) $(CFLAGS) $(OBJS) -o$(BIN) -l:cli.a -lreadline
+
+$(SRCS:.c=.d):%.d:%.c
+	$(CC) $(CFLAGS) -MM $< >$@
+
+include $(SRCS:.c=.d)
 
 .PHONY: clean
 clean:
-	$(RM) ${OBJS} ${BINS}
+	-${RM} ${BIN} ${OBJS} $(SRCS:.c=.d)
+

--- a/src/cli/example/testshell.c
+++ b/src/cli/example/testshell.c
@@ -57,7 +57,7 @@ int main()
         }
         else
         {
-            do_cmd(c,&quit, NULL);
+            do_cmd(c,&quit, NULL, table);
             // Add valid input to readline history.
             add_history(input);
         }

--- a/src/cli/example/testshell.c
+++ b/src/cli/example/testshell.c
@@ -31,7 +31,7 @@ char *trim_newline(char *s)
 
 int main()
 {
-    lookup_t ** table = initialize_lookup();
+    lookup_t **table = initialize_lookup();
     int quit = 1;
     char *cmd_string;
     greet();

--- a/src/cli/example/testshell.c
+++ b/src/cli/example/testshell.c
@@ -67,7 +67,7 @@ int main()
         //cmd_free(c);
         free(input);
     }
-    delete_entries(**table);
+    delete_entries(table);
 
     return 0;
 }

--- a/src/cli/example/testshell.c
+++ b/src/cli/example/testshell.c
@@ -31,7 +31,7 @@ char *trim_newline(char *s)
 
 int main()
 {
-    lookup_t * table = initialize_lookup();
+    lookup_t ** table = initialize_lookup();
     int quit = 1;
     char *cmd_string;
     greet();
@@ -67,7 +67,7 @@ int main()
         //cmd_free(c);
         free(input);
     }
-    delete_entries(table);
+    delete_entries(**table);
 
     return 0;
 }

--- a/src/cli/include/cmd.h
+++ b/src/cli/include/cmd.h
@@ -2,10 +2,10 @@
 #define _CLI_INCLUDE_CMD_H
 #include "parser.h"
 #include "operations.h"
-#include "../../game-state/include/game.h"
-#include "../../common/include/uthash.h"
-#include "../../action_management/include/action_structs.h"
-#include "../../action_management/include/actionmanagement.h"
+#include "game.h"
+#include "uthash.h"
+#include "action_structs.h"
+#include "actionmanagement.h"
 //#include "../../game-state/include/game.h"
 
 /* Operation data type */

--- a/src/cli/include/cmd.h
+++ b/src/cli/include/cmd.h
@@ -4,17 +4,19 @@
 #include "operations.h"
 #include "../../game-state/include/game.h"
 #include "../../common/include/uthash.h"
+#include "../../action_management/include/action_structs.h"
+#include "../../action_management/include/actionmanagement.h"
 //#include "../../game-state/include/game.h"
 
 /* Operation data type */
-typedef char * operation(char *tokens[TOKEN_LIST_SIZE], game_t * game);
+typedef char *operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
 
 // Lookup entry for hashtable, using uthash.
 typedef struct lookup_entry
 {
-    char * name; // key
-    operation * operation_type;
-    // * action_t action_type;
+    char *name; // key
+    operation *operation_type;
+    action_type_t *action;
     UT_hash_handle hh;
 } lookup_t;
 
@@ -30,7 +32,7 @@ typedef struct
 /* Iteratively adds each action, and its synonyms into the table. Commented out
 until action_t is ready */
 
-//void add_action_entries(action_t * action_value);
+void add_action_entries(lookup_t **table);
 
 /* Adds entry into hashtable
  *
@@ -41,7 +43,7 @@ until action_t is ready */
  * Returns:
  * - nothing
  */
-void add_entry(char * command_name, operation * associated_operation, lookup_t * * table);
+void add_entry(char *command_name, operation *associated_operation, lookup_t **table);
 
 /* Finds entry in hashtable with the given name.
  *
@@ -52,7 +54,7 @@ void add_entry(char * command_name, operation * associated_operation, lookup_t *
  * Returns:
  * - a pointer to the entire entry
  */
-lookup_t * find_entry(char * command_name, lookup_t * * table);
+lookup_t *find_entry(char *command_name, lookup_t **table);
 
 
 /* Finds operation in hashtable corresponding to the given name.
@@ -64,7 +66,7 @@ lookup_t * find_entry(char * command_name, lookup_t * * table);
  * Returns:
  * - a pointer to the corresponding operation
  */
-operation * find_operation(char * command_name, lookup_t * * table);
+operation *find_operation(char *command_name, lookup_t **table);
 /* Finds action in hashtable corresponding to the given name.
  *
  *
@@ -75,7 +77,7 @@ operation * find_operation(char * command_name, lookup_t * * table);
  * - a pointer to the corresponding action
  * - NULL if the command is not an action.
  */
-//action_t * find_action(char * command_name, lookup_t * table);
+action_type_t *find_action(char *command_name, lookup_t *table);
 /*  Commented out until action_t is ready.*/
 
 
@@ -88,7 +90,7 @@ operation * find_operation(char * command_name, lookup_t * * table);
  * Returns:
  * - nothing
  */
-void delete_entry(char * command_name, lookup_t * * table);
+void delete_entry(char *command_name, lookup_t **table);
 
 /* Clears out the entire table, and frees it too!
  *
@@ -99,14 +101,14 @@ void delete_entry(char * command_name, lookup_t * * table);
  * Returns:
  * - nothing
  */
-void delete_entries(lookup_t * * table);
+void delete_entries(lookup_t **table);
 
 
 /* Puts stuff into table, for testing purposes
  * You can see what is in there in the .c file.
  * Returns a pointer to the new table.
  */
-lookup_t * * initialize_lookup();
+lookup_t **initialize_lookup();
 
 
 /* Heap allocates a new cmd struct
@@ -168,7 +170,7 @@ void cmd_show(cmd *c);
  * Returns:
  * - pointer to command struct, NULL if parse fails
  */
-cmd *cmd_from_string(char *s, lookup_t * table);
+cmd *cmd_from_string(char *s, lookup_t *table);
 
 
 /*
@@ -180,7 +182,7 @@ cmd *cmd_from_string(char *s, lookup_t * table);
  * Returns:
  * - pointer to a cmd struct, NULL if there is an error
  */
-cmd *cmd_from_tokens(char **ts, lookup_t * table);
+cmd *cmd_from_tokens(char **ts, lookup_t *table);
 
 
 /*
@@ -193,6 +195,6 @@ cmd *cmd_from_tokens(char **ts, lookup_t * table);
  * Returns:
  * - nothing -> output handled elsewhere
  */
-void do_cmd(cmd *c,int *quit, game_t * game);
+void do_cmd(cmd *c,int *quit, game_t *game);
 
 #endif /* _CLI_INCLUDE_CMD_H */

--- a/src/cli/include/cmd.h
+++ b/src/cli/include/cmd.h
@@ -1,7 +1,7 @@
 #ifndef _CLI_INCLUDE_CMD_H
 #define _CLI_INCLUDE_CMD_H
 #include "parser.h"
-#include "operations.h"
+
 #include "game.h"
 #include "uthash.h"
 #include "action_structs.h"
@@ -27,7 +27,7 @@ typedef struct
     char **tokens;    //should be of TOKEN_LIST_SIZE
     operation *func_of_cmd;
 } cmd;
-
+#include "operations.h"
 
 /* Iteratively adds each action, and its synonyms into the table. Commented out
 until action_t is ready */

--- a/src/cli/include/cmd.h
+++ b/src/cli/include/cmd.h
@@ -9,7 +9,8 @@
 //#include "../../game-state/include/game.h"
 
 /* Operation data type */
-typedef char *operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
+typedef struct lookup_entry lookup_t;
+typedef char *operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **table);
 
 // Lookup entry for hashtable, using uthash.
 typedef struct lookup_entry
@@ -19,7 +20,6 @@ typedef struct lookup_entry
     action_type_t *action;
     UT_hash_handle hh;
 } lookup_t;
-
 
 /* Command data type */
 typedef struct
@@ -77,7 +77,7 @@ operation *find_operation(char *command_name, lookup_t **table);
  * - a pointer to the corresponding action
  * - NULL if the command is not an action.
  */
-action_type_t *find_action(char *command_name, lookup_t *table);
+action_type_t *find_action(char *command_name, lookup_t **table);
 /*  Commented out until action_t is ready.*/
 
 
@@ -195,6 +195,6 @@ cmd *cmd_from_tokens(char **ts, lookup_t **table);
  * Returns:
  * - nothing -> output handled elsewhere
  */
-void do_cmd(cmd *c,int *quit, game_t *game);
+void do_cmd(cmd *c,int *quit, game_t *game, lookup_t **table);
 
 #endif /* _CLI_INCLUDE_CMD_H */

--- a/src/cli/include/cmd.h
+++ b/src/cli/include/cmd.h
@@ -170,7 +170,7 @@ void cmd_show(cmd *c);
  * Returns:
  * - pointer to command struct, NULL if parse fails
  */
-cmd *cmd_from_string(char *s, lookup_t *table);
+cmd *cmd_from_string(char *s, lookup_t **table);
 
 
 /*
@@ -182,7 +182,7 @@ cmd *cmd_from_string(char *s, lookup_t *table);
  * Returns:
  * - pointer to a cmd struct, NULL if there is an error
  */
-cmd *cmd_from_tokens(char **ts, lookup_t *table);
+cmd *cmd_from_tokens(char **ts, lookup_t **table);
 
 
 /*

--- a/src/cli/include/operations.h
+++ b/src/cli/include/operations.h
@@ -2,6 +2,10 @@
 #define _CLI_INCLUDE_OPERATIONS_H
 #include "cmd.h"
 #include "../../game-state/include/game.h"
+#include "../../game-state/include/path.h"
+#include "../../action_management/include/actionmanagement.h"
+
+typedef struct lookup_t lookup;
 
 /*
  * We list all demanded operations over here.
@@ -28,7 +32,7 @@
  *
  * Note that this command literally does nothing right now.
  */
-char *quit_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game);
+char *quit_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
 
 
 /* Generate a list of supported operations,
@@ -40,7 +44,7 @@ char *quit_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game);
  * Returns:
  * - Said list of supported operations as a string
  */
-char *help_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game);
+char *help_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
 
 
 /*
@@ -53,7 +57,7 @@ char *help_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game);
  * Returns:
  * - Said list of previous actions as a string
  */
-char *hist_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game);
+char *hist_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
 
 
 /*
@@ -79,7 +83,7 @@ char *save_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
  * Returns:
  * - Said description as a string
  */
-char *look_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game);
+char *look_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
 
 
 /*Returns a description of the player inventory contents
@@ -90,7 +94,7 @@ char *look_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game);
  * Returns:
  * - Said description as a string
  */
-char *inventory_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game);
+char *inventory_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
 
 
 /* Error Operations that returns an error message as string
@@ -101,7 +105,7 @@ char *inventory_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game);
  * Returns:
  * - Said error message as a string
  */
-char *action_error_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game);
+char *action_error_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
 
 
 /* These functions will generate an action-struct (based on action management)
@@ -114,9 +118,9 @@ char *action_error_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game);
  * - Said list of supported operations as a string
  *
  */
-char *type1_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game);
-char *type2_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game);
-char *type3_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game);
+char *type1_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game, lookup **table);
+char *type2_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game, lookup **table);
+char *type3_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game, lookup **table);
 //char *type4_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game);
 
 #endif /* _CLI_INCLUDE_OPERATIONS_H */

--- a/src/cli/include/operations.h
+++ b/src/cli/include/operations.h
@@ -32,7 +32,7 @@ typedef struct lookup_t lookup;
  *
  * Note that this command literally does nothing right now.
  */
-char *quit_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
+char *quit_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table);
 
 
 /* Generate a list of supported operations,
@@ -44,7 +44,7 @@ char *quit_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
  * Returns:
  * - Said list of supported operations as a string
  */
-char *help_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
+char *help_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table);
 
 
 /*
@@ -57,7 +57,7 @@ char *help_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
  * Returns:
  * - Said list of previous actions as a string
  */
-char *hist_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
+char *hist_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table);
 
 
 /*
@@ -71,7 +71,7 @@ char *hist_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
  * Returns:
  * - A success or error message
  */
-char *save_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
+char *save_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table);
 
 /*
  * Returns a description of either a specefied item, or the room
@@ -83,7 +83,7 @@ char *save_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
  * Returns:
  * - Said description as a string
  */
-char *look_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
+char *look_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table);
 
 
 /*Returns a description of the player inventory contents
@@ -94,7 +94,7 @@ char *look_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
  * Returns:
  * - Said description as a string
  */
-char *inventory_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
+char *inventory_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table);
 
 
 /* Error Operations that returns an error message as string
@@ -105,7 +105,7 @@ char *inventory_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
  * Returns:
  * - Said error message as a string
  */
-char *action_error_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game);
+char *action_error_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table);
 
 
 /* These functions will generate an action-struct (based on action management)

--- a/src/cli/include/operations.h
+++ b/src/cli/include/operations.h
@@ -5,7 +5,7 @@
 #include "path.h"
 #include "actionmanagement.h"
 
-typedef struct lookup_t lookup;
+//typedef lookup_entry lookup_t;
 
 /*
  * We list all demanded operations over here.
@@ -32,7 +32,7 @@ typedef struct lookup_t lookup;
  *
  * Note that this command literally does nothing right now.
  */
-char *quit_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table);
+char *quit_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **table);
 
 
 /* Generate a list of supported operations,
@@ -44,7 +44,7 @@ char *quit_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table
  * Returns:
  * - Said list of supported operations as a string
  */
-char *help_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table);
+char *help_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **table);
 
 
 /*
@@ -57,7 +57,7 @@ char *help_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table
  * Returns:
  * - Said list of previous actions as a string
  */
-char *hist_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table);
+char *hist_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **table);
 
 
 /*
@@ -71,7 +71,7 @@ char *hist_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table
  * Returns:
  * - A success or error message
  */
-char *save_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table);
+char *save_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **table);
 
 /*
  * Returns a description of either a specefied item, or the room
@@ -83,7 +83,7 @@ char *save_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table
  * Returns:
  * - Said description as a string
  */
-char *look_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table);
+char *look_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **table);
 
 
 /*Returns a description of the player inventory contents
@@ -94,7 +94,7 @@ char *look_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table
  * Returns:
  * - Said description as a string
  */
-char *inventory_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table);
+char *inventory_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **table);
 
 
 /* Error Operations that returns an error message as string
@@ -105,7 +105,7 @@ char *inventory_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **
  * Returns:
  * - Said error message as a string
  */
-char *action_error_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table);
+char *action_error_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **table);
 
 
 /* These functions will generate an action-struct (based on action management)
@@ -118,9 +118,9 @@ char *action_error_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup
  * - Said list of supported operations as a string
  *
  */
-char *type1_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game, lookup **table);
-char *type2_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game, lookup **table);
-char *type3_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game, lookup **table);
+char *type1_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game, lookup_t **table);
+char *type2_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game, lookup_t **table);
+char *type3_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game, lookup_t **table);
 //char *type4_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t * game);
 
 #endif /* _CLI_INCLUDE_OPERATIONS_H */

--- a/src/cli/include/operations.h
+++ b/src/cli/include/operations.h
@@ -1,9 +1,9 @@
 #ifndef _CLI_INCLUDE_OPERATIONS_H
 #define _CLI_INCLUDE_OPERATIONS_H
 #include "cmd.h"
-#include "../../game-state/include/game.h"
-#include "../../game-state/include/path.h"
-#include "../../action_management/include/actionmanagement.h"
+#include "game.h"
+#include "path.h"
+#include "actionmanagement.h"
 
 typedef struct lookup_t lookup;
 

--- a/src/cli/include/validate.h
+++ b/src/cli/include/validate.h
@@ -29,7 +29,7 @@
  *    If the action is invalid, assigns the cmd pointer
  *    to action_error_operation
  */
-cmd *assign_action(char *ts[TOKEN_LIST_SIZE], lookup_t *table);
+cmd *assign_action(char *ts[TOKEN_LIST_SIZE], lookup_t **table);
 
 
 /*
@@ -42,7 +42,7 @@ cmd *assign_action(char *ts[TOKEN_LIST_SIZE], lookup_t *table);
  * Returns:
  *  - FALSE if the action is not supported; TRUE if it is.
  */
-bool validate_action(char *tokens[TOKEN_LIST_SIZE], lookup_t *table);
+bool validate_action(char *tokens[TOKEN_LIST_SIZE], lookup_t **table);
 
 
 /*

--- a/src/cli/src/cmd.c
+++ b/src/cli/src/cmd.c
@@ -92,7 +92,6 @@ lookup_t **initialize_lookup()
 {
     lookup_t **table = malloc(sizeof(*table));
     add_entry("QUIT", quit_operation, table);
-    printf("%d\n",HASH_COUNT(*table));
     add_entry("HELP", help_operation, table);
     add_entry("HIST", hist_operation, table);
     add_entry("LOOK",look_operation, table);

--- a/src/cli/src/cmd.c
+++ b/src/cli/src/cmd.c
@@ -14,7 +14,6 @@ void add_entry(char *command_name, operation *associated_operation, lookup_t **t
     t->name = command_name;
     t->operation_type = associated_operation;
     HASH_ADD_KEYPTR(hh, *table, t->name, strlen(t->name), t);
-    printf("%d\n",HASH_COUNT(*table));
 
     /* This is code for how we will print once we get UI context structs, ideally they
        will provide a function for printing so we don't have to lookup x and y coordinates
@@ -35,21 +34,16 @@ void add_action_entries(lookup_t **table){
     while(all_actions->next != NULL)
     {
         action_type_t *curr_action = all_actions->act;
-        lookup_t *t = malloc(sizeof(lookup_t));
 
-        t->name = curr_action->c_name;
         if(curr_action->kind == 1) {
-            t->operation_type = type1_action_operation;
+            add_entry(curr_action->c_name, type1_action_operation, table);
         }
         else if(curr_action->kind == 2) {
-            t->operation_type = type2_action_operation;
+            add_entry(curr_action->c_name, type2_action_operation, table);
         }
         else if(curr_action->kind == 3) {
-            t->operation_type = type3_action_operation;
+            add_entry(curr_action->c_name, type2_action_operation, table);
         }
-
-        HASH_ADD_KEYPTR(hh, *table, t->name, strlen(t->name), t);
-        printf("%d\n",HASH_COUNT(*table));
 
         all_actions = all_actions->next;
     }
@@ -71,7 +65,7 @@ operation *find_operation(char *command_name, lookup_t **table)
     return NULL;
 }
 
-action_type_t *find_action(char *command_name, lookup_t *table){
+action_type_t *find_action(char *command_name, lookup_t **table){
   return find_entry(command_name, table)->action;
 }
 
@@ -97,12 +91,10 @@ void delete_entries(lookup_t **table)
 lookup_t **initialize_lookup()
 {
     lookup_t **table = malloc(sizeof(*table));
-    add_entry("QUIT", quit_operation,  table);
-    printf("%d\n",HASH_COUNT(*table) );
+    add_entry("QUIT", quit_operation, table);
+    printf("%d\n",HASH_COUNT(*table));
     add_entry("HELP", help_operation, table);
-    add_entry("HIST", hist_operation,  table);
-    add_entry("TAKE", type1_action_operation,table);
-    add_entry("PUT", type3_action_operation, table);
+    add_entry("HIST", hist_operation, table);
     add_entry("LOOK",look_operation, table);
     add_entry("INV", inventory_operation, table);
     add_entry("SAVE", save_operation, table);
@@ -185,18 +177,18 @@ cmd *cmd_from_string(char *s, lookup_t **table)
 /* =================================== */
 
 /* See cmd.h */
-void do_cmd(cmd *c,int *quit, game_t *game)
+void do_cmd(cmd *c,int *quit, game_t *game, lookup_t **table)
 {
     char *outstring;
     /* available commands are QUIT, STATS, CHAR, LOOKUP, HELP, READ */
     if (strcmp(cmd_name_tos(c),"QUIT")==0)
     {
         *quit=0;
-        (*(c->func_of_cmd))(c->tokens, game);
+        (*(c->func_of_cmd))(c->tokens, game, table);
     }
     else
     {
-        outstring = (*(c->func_of_cmd))(c->tokens, game);
+        outstring = (*(c->func_of_cmd))(c->tokens, game, table);
         if(outstring!=NULL)
             printf("%s\n",outstring );
     }

--- a/src/cli/src/cmd.c
+++ b/src/cli/src/cmd.c
@@ -5,7 +5,6 @@
 #include "shell.h"
 #include "cmd.h"
 #include "validate.h"
-
 /* === hashtable constructors === */
 
 void add_entry(char *command_name, operation *associated_operation, lookup_t **table)
@@ -18,7 +17,8 @@ void add_entry(char *command_name, operation *associated_operation, lookup_t **t
     /* This is code for how we will print once we get UI context structs, ideally they
        will provide a function for printing so we don't have to lookup x and y coordinates
        every time. Ignore this for now.
-
+       char * (*)(char **, game_t *, lookup_t **) {aka char * (*)(char **, struct <anonymous> *, struct lookup_entry **)}
+       char * (*)(char **, game_t *, lookup **) {aka char * (*)(char **, struct <anonymous> *, struct lookup_t **)}
        int y;
        int x;
        getyx(win->w, y, x);
@@ -61,7 +61,7 @@ lookup_t *find_entry(char *command_name, lookup_t **table)
 operation *find_operation(char *command_name, lookup_t **table)
 {
     lookup_t *t;
-    if (t = find_entry(command_name, table)) return t->operation_type;
+    if ((t = find_entry(command_name, table))) return t->operation_type;
     return NULL;
 }
 

--- a/src/cli/src/cmd.c
+++ b/src/cli/src/cmd.c
@@ -163,14 +163,14 @@ void cmd_show(cmd *c)
 /* === command parsing === */
 
 /* See cmd.h */
-cmd *cmd_from_tokens(char **ts, lookup_t *table)
+cmd *cmd_from_tokens(char **ts, lookup_t **table)
 {
     cmd *output = assign_action(ts, table);
     return output;
 }
 
 /* See cmd.h */
-cmd *cmd_from_string(char *s, lookup_t *table)
+cmd *cmd_from_string(char *s, lookup_t **table)
 {
     char **parsed_input = parse(s);
     if(parsed_input == NULL)

--- a/src/cli/src/cmd.c
+++ b/src/cli/src/cmd.c
@@ -50,6 +50,8 @@ void add_action_entries(lookup_t **table){
 
         HASH_ADD_KEYPTR(hh, *table, t->name, strlen(t->name), t);
         printf("%d\n",HASH_COUNT(*table));
+
+        all_actions = all_actions->next;
     }
 
 

--- a/src/cli/src/cmd.c
+++ b/src/cli/src/cmd.c
@@ -26,22 +26,26 @@ void add_entry(char *command_name, operation *associated_operation, lookup_t **t
     */
 }
 
-void add_action_entries(lookup_t **table){
- //To be filled with a while loop that adds each synonym,
- //and maps the enum in the action value to the proper operation.
+void add_action_entries(lookup_t **table)
+{
+//To be filled with a while loop that adds each synonym,
+//and maps the enum in the action value to the proper operation.
     list_action_type_t *all_actions = get_supported_actions();
 
-    while(all_actions->next != NULL)
+    while(all_actions != NULL)
     {
         action_type_t *curr_action = all_actions->act;
 
-        if(curr_action->kind == 1) {
+        if(curr_action->kind == 1)
+        {
             add_entry(curr_action->c_name, type1_action_operation, table);
         }
-        else if(curr_action->kind == 2) {
+        else if(curr_action->kind == 2)
+        {
             add_entry(curr_action->c_name, type2_action_operation, table);
         }
-        else if(curr_action->kind == 3) {
+        else if(curr_action->kind == 3)
+        {
             add_entry(curr_action->c_name, type2_action_operation, table);
         }
 
@@ -65,8 +69,9 @@ operation *find_operation(char *command_name, lookup_t **table)
     return NULL;
 }
 
-action_type_t *find_action(char *command_name, lookup_t **table){
-  return find_entry(command_name, table)->action;
+action_type_t *find_action(char *command_name, lookup_t **table)
+{
+    return find_entry(command_name, table)->action;
 }
 
 

--- a/src/cli/src/operations.c
+++ b/src/cli/src/operations.c
@@ -29,12 +29,12 @@ char *hist_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **tab
 /* See operations.h */
 char *save_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **table)
 {
-/*  if(tokens[1] == NULL){
-    fprintf(stderr,"Save Error, No filename specified. \n");
-  }
-  if (validate(tokens[1]) == true){
-    int sv = save(game, tokens[1]);
-*/  return NULL;
+    /*  if(tokens[1] == NULL){
+        fprintf(stderr,"Save Error, No filename specified. \n");
+      }
+      if (validate(tokens[1]) == true){
+        int sv = save(game, tokens[1]);
+    */  return NULL;
 }
 
 char *look_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **table)
@@ -64,12 +64,12 @@ char *type1_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup
     item_t *curr_item;
     ITER_ALL_ITEMS_IN_ROOM(game->curr_room, curr_item)
     {
-	if (strcmp(curr_item->item_id,tokens[1])==0)
-	{
-        action_type_t *action = find_action(tokens[0], table);
-        do_item_action(game, action, curr_item);
-		return "The object is found\n";
-	}
+        if (strcmp(curr_item->item_id,tokens[1])==0)
+        {
+            action_type_t *action = find_action(tokens[0], table);
+            do_item_action(game, action, curr_item);
+            return "The object is found\n";
+        }
     }
     return "The object could not be found\n";
 }
@@ -106,11 +106,11 @@ char *type3_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup
 
     ITER_ALL_ITEMS_IN_ROOM(game->curr_room, item1)
     {
-	if (strcmp(item1->item_id,tokens[1])==0)
-	{
-		find_it1 = 0;
-	}
-	if (strcmp(item2->item_id,tokens[3])==0)
+        if (strcmp(item1->item_id,tokens[1])==0)
+        {
+            find_it1 = 0;
+        }
+        if (strcmp(item2->item_id,tokens[3])==0)
         {
             find_it2 = 0;
         }

--- a/src/cli/src/operations.c
+++ b/src/cli/src/operations.c
@@ -9,25 +9,25 @@
 // remove the comment as soon as checkpointing removes their dummy struct
 //#include "../../checkpointing/include/save.h"
 
-char *quit_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game)
+char *quit_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table)
 {
     return NULL;
 }
 
-char *help_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game)
+char *help_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table)
 {
     help_text();
     return NULL;
 }
 
-char *hist_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game)
+char *hist_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table)
 {
     print_history();
     return NULL;
 }
 
 /* See operations.h */
-char *save_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game)
+char *save_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table)
 {
 /*  if(tokens[1] == NULL){
     fprintf(stderr,"Save Error, No filename specified. \n");
@@ -37,7 +37,7 @@ char *save_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game)
 */  return NULL;
 }
 
-char *look_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game)
+char *look_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table)
 {
     if(tokens[1]==NULL)
     {
@@ -127,12 +127,12 @@ char *type3_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup
 }
 
 
-char *action_error_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game)
+char *action_error_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table)
 {
     return "You cannot perform this action !";
 }
 
-char *inventory_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game)
+char *inventory_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table)
 {
     item_t *t;
     int i = 0;

--- a/src/cli/src/operations.c
+++ b/src/cli/src/operations.c
@@ -5,6 +5,7 @@
 #include "shell.h"
 #include "assert.h"
 #include "validate.h"
+
 // remove the comment as soon as checkpointing removes their dummy struct
 //#include "../../checkpointing/include/save.h"
 
@@ -54,7 +55,7 @@ char *look_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game)
 }
 
 //KIND 1:   ACTION <item>
-char *type1_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game)
+char *type1_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table)
 {
     if(tokens[1]==NULL)
     {
@@ -65,7 +66,8 @@ char *type1_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game)
     {
 	if (strcmp(curr_item->item_id,tokens[1])==0)
 	{
-		// call action magement function
+        action_type_t *action = find_action(tokens[0], table);
+        do_item_action(game, action, curr_item);
 		return "The object is found\n";
 	}
     }
@@ -73,14 +75,26 @@ char *type1_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game)
 }
 
 //KIND 2:   ACTION <direction>
-char *type2_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game)
+char *type2_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table)
 {
-    printf("%s\n",tokens[0] );
-    return "is a direction action!";
+    path_t *curr_path;
+    ITER_ALL_PATHS(game->curr_room, curr_path)
+    {
+        if (strcmp(curr_path->direction,tokens[1])==0)
+        {
+            action_type_t *action = find_action(tokens[0], table);
+            do_path_action(game, action, curr_path);
+            return "Direction available!\n";
+        }
+    }
+
+    return "You cannot go in this direction\n";
+    
+    
 }
 
 //KIND 3:   ACTION <item> <item>
-char *type3_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game)
+char *type3_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table)
 {
     if(tokens[1]==NULL || tokens[3]==NULL)
     {
@@ -107,7 +121,8 @@ char *type3_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game)
         return "The object(s) could not be found";
     }
 
-	// call action management function
+    action_type_t *action = find_action(tokens[0], table);
+    do_item_item_action(game, action, item1, item2);
     return "is an action!";
 }
 
@@ -136,8 +151,3 @@ char *inventory_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game)
 //    return "is an action!";
 //}
 
-void create_type1_action(char *tokens[TOKEN_LIST_SIZE], game_t *game) {}
-void create_type2_action(char *tokens[TOKEN_LIST_SIZE], game_t *game) {}
-void create_type3_action(char *tokens[TOKEN_LIST_SIZE], game_t *game) {}
-
-//void create_type4_action(char *tokens[TOKEN_LIST_SIZE], game_t *game) {}

--- a/src/cli/src/operations.c
+++ b/src/cli/src/operations.c
@@ -9,25 +9,25 @@
 // remove the comment as soon as checkpointing removes their dummy struct
 //#include "../../checkpointing/include/save.h"
 
-char *quit_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table)
+char *quit_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **table)
 {
     return NULL;
 }
 
-char *help_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table)
+char *help_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **table)
 {
     help_text();
     return NULL;
 }
 
-char *hist_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table)
+char *hist_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **table)
 {
     print_history();
     return NULL;
 }
 
 /* See operations.h */
-char *save_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table)
+char *save_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **table)
 {
 /*  if(tokens[1] == NULL){
     fprintf(stderr,"Save Error, No filename specified. \n");
@@ -37,7 +37,7 @@ char *save_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table
 */  return NULL;
 }
 
-char *look_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table)
+char *look_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **table)
 {
     if(tokens[1]==NULL)
     {
@@ -55,7 +55,7 @@ char *look_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table
 }
 
 //KIND 1:   ACTION <item>
-char *type1_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table)
+char *type1_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **table)
 {
     if(tokens[1]==NULL)
     {
@@ -75,7 +75,7 @@ char *type1_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup
 }
 
 //KIND 2:   ACTION <direction>
-char *type2_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table)
+char *type2_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **table)
 {
     path_t *curr_path;
     ITER_ALL_PATHS(game->curr_room, curr_path)
@@ -89,12 +89,12 @@ char *type2_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup
     }
 
     return "You cannot go in this direction\n";
-    
-    
+
+
 }
 
 //KIND 3:   ACTION <item> <item>
-char *type3_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table)
+char *type3_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **table)
 {
     if(tokens[1]==NULL || tokens[3]==NULL)
     {
@@ -102,8 +102,8 @@ char *type3_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup
     }
 
     item_t *item1, *item2;
-    int find_it1 = 1, find_it2 = 1; // set to be 0 if an item is found 
-    
+    int find_it1 = 1, find_it2 = 1; // set to be 0 if an item is found
+
     ITER_ALL_ITEMS_IN_ROOM(game->curr_room, item1)
     {
 	if (strcmp(item1->item_id,tokens[1])==0)
@@ -111,11 +111,11 @@ char *type3_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup
 		find_it1 = 0;
 	}
 	if (strcmp(item2->item_id,tokens[3])==0)
-        {   
+        {
             find_it2 = 0;
         }
     }
-    
+
     if(find_it1 == 1 || find_it2 == 1)
     {
         return "The object(s) could not be found";
@@ -127,12 +127,12 @@ char *type3_action_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup
 }
 
 
-char *action_error_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table)
+char *action_error_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **table)
 {
     return "You cannot perform this action !";
 }
 
-char *inventory_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **table)
+char *inventory_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup_t **table)
 {
     item_t *t;
     int i = 0;
@@ -150,4 +150,3 @@ char *inventory_operation(char *tokens[TOKEN_LIST_SIZE], game_t *game, lookup **
 //    printf("%s\n",tokens[0] );
 //    return "is an action!";
 //}
-

--- a/src/cli/src/parser.c
+++ b/src/cli/src/parser.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
-#include "../include/parser.h"
+#include "parser.h"
 
 /* See parser.h */
 char **parse(char *input)

--- a/src/cli/src/validate.c
+++ b/src/cli/src/validate.c
@@ -57,15 +57,19 @@ bool validate_ind_objects(char *tokens[TOKEN_LIST_SIZE], game_t * game)
 /* See validate.h */
 bool validate_filename(char *filename)
 {
-  int len = strlen(filename);
-  if(len < 4){
-    return false;
-  }
-  const char *ending = &filename[len-4];
-  int cmp = strcmp(ending, ".dat");
-  if(cmp == 0){
-    return true;
-  } else {
-    return false;
-  }
+    int len = strlen(filename);
+    if(len < 4)
+    {
+        return false;
+    }
+    const char *ending = &filename[len-4];
+    int cmp = strcmp(ending, ".dat");
+    if(cmp == 0)
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }

--- a/src/cli/src/validate.c
+++ b/src/cli/src/validate.c
@@ -27,7 +27,7 @@ cmd *assign_action(char **ts, lookup_t ** table)
 }
 
 /* See validate.h */
-bool validate_action(char *tokens[TOKEN_LIST_SIZE], lookup_t * table)
+bool validate_action(char *tokens[TOKEN_LIST_SIZE], lookup_t ** table)
 {
     return true;
 }

--- a/src/cli/src/validate.c
+++ b/src/cli/src/validate.c
@@ -16,7 +16,7 @@
 
 
 /* See validate.h */
-cmd *assign_action(char **ts, lookup_t * table)
+cmd *assign_action(char **ts, lookup_t ** table)
 {
     cmd *output = cmd_new(ts);
     output->func_of_cmd = find_operation(ts[0], table);

--- a/src/game-state/include/game_state_common.h
+++ b/src/game-state/include/game_state_common.h
@@ -7,8 +7,8 @@
 #include <string.h>
 #include <math.h>
 #include <assert.h>
-#include "uthash.h"
-#include "utlist.h"
+#include "../../common/include/uthash.h"
+#include "../../common/include/utlist.h"
 
 #define MAX_ID_LEN 20
 #define MAX_SDESC_LEN 50

--- a/src/game-state/include/game_state_common.h
+++ b/src/game-state/include/game_state_common.h
@@ -7,8 +7,8 @@
 #include <string.h>
 #include <math.h>
 #include <assert.h>
-#include "../../common/include/uthash.h"
-#include "../../common/include/utlist.h"
+#include "uthash.h"
+#include "utlist.h"
 
 #define MAX_ID_LEN 20
 #define MAX_SDESC_LEN 50


### PR DESCRIPTION
This PR integrates our code with action management. We are now calling action management's functions in our type action operations, which are associated with different commands through the hashtable. We have also implemented the add_action_entries for the hashtable. This also includes a Makefile fix so that we can use other teams functions, and we no longer need to use absolute paths in our include statements. (These include statements have already been updated in this branch). Currently calling any actions will result in the action error operations, but this will be fixed once action management gets their hotfix through.