### PR TITLE
Hotfix: Memset everything immediately after malloc & fix errors for desc strings in room

### DIFF
--- a/src/game-state/src/game.c
+++ b/src/game-state/src/game.c
@@ -5,8 +5,7 @@
 /* see game.h */
 game_t *game_new() {
     game_t *game = malloc(sizeof(game_t));
-    game->all_players = NULL; //helper fxn to get list of players
-    game->all_rooms = NULL;
+    memset(game, 0, sizeof(game_t));
 
     /* read from the file using interface from WDL team */
 

--- a/src/game-state/src/item.c
+++ b/src/game-state/src/item.c
@@ -28,6 +28,7 @@ int item_init(item_t *new_item, char *item_id, char *short_desc, char *long_desc
 item_t *item_new(char *item_id, char *short_desc, char *long_desc)
 {
     item_t *new_item = malloc(sizeof(item_t));
+    memset(new_item, 0, sizeof(item_t));
     new_item->item_id = malloc(MAX_ID_LEN * sizeof(char)); // tentative size allocation
     new_item->short_desc = malloc(MAX_SDESC_LEN * sizeof(char));
     new_item->long_desc = malloc(MAX_LDESC_LEN * sizeof(char));
@@ -90,7 +91,7 @@ int add_attribute_to_hash(attribute_hash_t attribute_hash, attribute_t* new_attr
   Returns:
     NULL if the attribute does not exist, pointer to attribute if it does
 */
-attribute_t *get_attribute(item_t *item, char *attr_name) 
+attribute_t *get_attribute(item_t *item, char *attr_name)
 {
     attribute_t* return_value;
     attribute_hash_t attribute_hash = item->attributes;
@@ -105,7 +106,7 @@ attribute_t *get_attribute(item_t *item, char *attr_name)
 int set_str_attr(item_t* item, char* attr_name, char* value)
 {
     attribute_t* res = get_attribute(item, attr_name);
-    if (res == NULL) 
+    if (res == NULL)
     {
         attribute_t* new_attribute = malloc(sizeof(attribute_t));
         new_attribute->attribute_tag = STRING;
@@ -118,7 +119,7 @@ int set_str_attr(item_t* item, char* attr_name, char* value)
     {
         res->attribute_value.str_val = value;
         return SUCCESS;
-    }    
+    }
 }
 
 
@@ -126,7 +127,7 @@ int set_str_attr(item_t* item, char* attr_name, char* value)
 int set_int_attr(item_t* item, char* attr_name, int value)
 {
     attribute_t* res = get_attribute(item, attr_name);
-    if (res == NULL) 
+    if (res == NULL)
     {
         attribute_t* new_attribute = malloc(sizeof(attribute_t));
         new_attribute->attribute_tag = INTEGER;
@@ -139,14 +140,14 @@ int set_int_attr(item_t* item, char* attr_name, int value)
     {
         res->attribute_value.int_val = value;
         return SUCCESS;
-    }    
+    }
 }
 
 /* see item.h */
 int set_double_attr(item_t* item, char* attr_name, double value)
 {
     attribute_t* res = get_attribute(item, attr_name);
-    if (res == NULL) 
+    if (res == NULL)
     {
         attribute_t* new_attribute = malloc(sizeof(attribute_t));
         new_attribute->attribute_tag = DOUBLE;
@@ -159,7 +160,7 @@ int set_double_attr(item_t* item, char* attr_name, double value)
     {
         res->attribute_value.double_val = value;
         return SUCCESS;
-    }    
+    }
 
 }
 
@@ -167,7 +168,7 @@ int set_double_attr(item_t* item, char* attr_name, double value)
 int set_char_attr(item_t* item, char* attr_name, char value)
 {
     attribute_t* res = get_attribute(item, attr_name);
-    if (res == NULL) 
+    if (res == NULL)
     {
         attribute_t* new_attribute = malloc(sizeof(attribute_t));
         new_attribute->attribute_tag = CHARACTER;
@@ -180,14 +181,14 @@ int set_char_attr(item_t* item, char* attr_name, char value)
     {
         res->attribute_value.char_val = value;
         return SUCCESS;
-    }    
+    }
 }
 
 /* see item.h */
 int set_bool_attr(item_t* item, char* attr_name, bool value)
 {
     attribute_t* res = get_attribute(item, attr_name);
-    if (res == NULL) 
+    if (res == NULL)
     {
         attribute_t* new_attribute = malloc(sizeof(attribute_t));
         new_attribute->attribute_tag = BOOLE;
@@ -200,7 +201,7 @@ int set_bool_attr(item_t* item, char* attr_name, bool value)
     {
         res->attribute_value.bool_val = value;
         return SUCCESS;
-    }    
+    }
 }
 
 /* see item.h */

--- a/src/game-state/src/path.c
+++ b/src/game-state/src/path.c
@@ -15,6 +15,7 @@ int delete_all_conditions(condition_list_t conditions) {
 /* See path.h */
 path_t *path_new(char *direction) {
     path_t *path = malloc(sizeof(path_t));
+    memset(path, 0, sizeof(path_t));
     path->direction = malloc(MAX_ID_LEN * sizeof(char));
     path->conditions = NULL;
 

--- a/src/game-state/src/player.c
+++ b/src/game-state/src/player.c
@@ -17,6 +17,7 @@ int player_init(player_t* plyr, int health) {
 player_t* player_new(int health) {
     player_t *plyr;
     plyr = malloc(sizeof(player_t));
+    memset(plyr, 0, sizeof(player_t));
 
     if(plyr == NULL)
     {
@@ -114,8 +115,8 @@ int add_item_to_player(player_t *player, item_t *item) {
 
 
 /* DISCARD
-IMPLEMENT function to find player given list and pid 
-See player_private.h 
+IMPLEMENT function to find player given list and pid
+See player_private.h
 player_t *get_player(player_hash_t all_players, char *player_id) {
     player_t
 }

--- a/src/game-state/src/room.c
+++ b/src/game-state/src/room.c
@@ -6,6 +6,7 @@
 /* See room.h */
 room_t *room_new(char *room_id, char *short_desc, char *long_desc) {
     room_t *room = malloc(sizeof(room_t));
+    memset(room, 0, sizeof(room_t));
     room->room_id = room_id;
     room->short_desc = short_desc;
     room->long_desc = long_desc;

--- a/src/game-state/src/room.c
+++ b/src/game-state/src/room.c
@@ -7,9 +7,15 @@
 room_t *room_new(char *room_id, char *short_desc, char *long_desc) {
     room_t *room = malloc(sizeof(room_t));
     memset(room, 0, sizeof(room_t));
-    room->room_id = room_id;
-    room->short_desc = short_desc;
-    room->long_desc = long_desc;
+
+    room->room_id = malloc(MAX_ID_LEN * sizeof(char)); // tentative size allocation
+    room->short_desc = malloc(MAX_SDESC_LEN * sizeof(char));
+    room->long_desc = malloc(MAX_LDESC_LEN * sizeof(char));
+
+    strcpy(room->room_id, item_id);
+    strcpy(room->short_desc, short_desc);
+    strcpy(room->long_desc, long_desc);
+
     room->items = NULL;
     room->paths = NULL;
     return room;

--- a/src/game-state/src/room.c
+++ b/src/game-state/src/room.c
@@ -12,7 +12,7 @@ room_t *room_new(char *room_id, char *short_desc, char *long_desc) {
     room->short_desc = malloc(MAX_SDESC_LEN * sizeof(char));
     room->long_desc = malloc(MAX_LDESC_LEN * sizeof(char));
 
-    strcpy(room->room_id, item_id);
+    strcpy(room->room_id, room_id);
     strcpy(room->short_desc, short_desc);
     strcpy(room->long_desc, long_desc);
 


### PR DESCRIPTION
 - Memset everything to 0 (NULL) immediately after malloc each struct, so that ui team doesn't get unexpected errors
 - Fix errors when init description strings of rooms: malloc and strcpy for the id, long_desc, & short_desc