### PR TITLE
Adding get description from item functions to game-state/dev

### DIFF
--- a/src/game-state/include/item.h
+++ b/src/game-state/include/item.h
@@ -74,6 +74,7 @@ int item_free(item_t *item_tofree);
  *
  * Returns:
  *  short description string
+ *  NULL if item is NULL
  */
 char *get_sdesc_item(item_t *item);
 
@@ -84,6 +85,7 @@ char *get_sdesc_item(item_t *item);
  *
  * Returns:
  *  long description string
+ *  NULL if item is NULL
  */
 char *get_ldesc_item(item_t *item);
 

--- a/src/game-state/include/item.h
+++ b/src/game-state/include/item.h
@@ -67,6 +67,26 @@ int item_init(item_t *new_item, char *item_id, char *short_desc, char *long_desc
 */
 int item_free(item_t *item_tofree);
 
+/* Get short description of item
+ *
+ * Parameters:
+ *  pointer to item
+ *
+ * Returns:
+ *  short description string
+ */
+char *get_sdesc_item(item_t *item);
+
+/* Get long description of item
+ *
+ * Parameters:
+ *  pointer to item
+ *
+ * Returns:
+ *  long description string
+ */
+char *get_ldesc_item(item_t *item);
+
 // ACTION STRUCTURE DEFINITION + BASIC FUNCTIONS ------------------------------
 
 // action_type_t written by AM, can be seen in action_structs.h

--- a/src/game-state/src/item.c
+++ b/src/game-state/src/item.c
@@ -84,12 +84,18 @@ game_action_t *game_action_new(char *act_name, action_type_t *act_type)
 /* see item.h */
 char *get_sdesc_item(item_t *item)
 {
+  if (item == NULL) {
+    return NULL;
+  }
   return item->short_desc;
 }
 
 /* see item.h */
 char *get_ldesc_item(item_t *item)
 {
+  if (item == NULL) {
+    return NULL;
+  }
   return item->long_desc;
 }
 

--- a/src/game-state/src/item.c
+++ b/src/game-state/src/item.c
@@ -81,6 +81,18 @@ game_action_t *game_action_new(char *act_name, action_type_t *act_type)
 
 }
 
+/* see item.h */
+char *get_sdesc_item(item_t *item)
+{
+  return item->short_desc;
+}
+
+/* see item.h */
+char *get_ldesc_item(item_t *item)
+{
+  return item->long_desc;
+}
+
 // ATTRIBUTE MANIPULATION FUNCTIONS -------------------------------------------
 /* see common-item.h */
 int add_attribute_to_hash(item_t* item, attribute_t* new_attribute) {

--- a/src/game-state/tests/test_items.c
+++ b/src/game-state/tests/test_items.c
@@ -48,6 +48,24 @@ Test(item, free)
 
 }
 
+/* Checks return of short description of item */
+Test(item, get_sdesc_item)
+{
+  item_t *new_item = item_new("item", "short", "long");
+
+  char *ret = get_sdesc_item(new_item);
+  cr_assert_eq(ret, new_item->short_desc, "get_sdesc_item() failed to return short description");
+}
+
+/* Checks return of long description of item */
+Test(item, get_ldesc_item)
+{
+  item_t *new_item = item_new("item", "short", "long");
+
+  char *ret = get_ldesc_item(new_item);
+  cr_assert_eq(ret, new_item->long_desc, "get_ldesc_item() failed to return long description");
+}
+
 // TESTS FOR ADD_ATRR_TO_HASH --------------------------------------------------
 
 /* Checks adding attribute to item hash */

--- a/src/game-state/tests/test_items.c
+++ b/src/game-state/tests/test_items.c
@@ -52,18 +52,26 @@ Test(item, free)
 Test(item, get_sdesc_item)
 {
   item_t *new_item = item_new("item", "short", "long");
-
+  item_t *null_item = NULL;
+  
   char *ret = get_sdesc_item(new_item);
+  char *null_ret = get_sdesc_item(null_item);
+
   cr_assert_eq(ret, new_item->short_desc, "get_sdesc_item() failed to return short description");
+  cr_assert_eq(null_ret, NULL, "get_sdesc_item() failed to return NULL for NULL item");
 }
 
 /* Checks return of long description of item */
 Test(item, get_ldesc_item)
 {
   item_t *new_item = item_new("item", "short", "long");
+  item_t *null_item = NULL;
 
   char *ret = get_ldesc_item(new_item);
+  char *null_ret = get_ldesc_item(null_item);
+
   cr_assert_eq(ret, new_item->long_desc, "get_ldesc_item() failed to return long description");
+  cr_assert_eq(null_ret, NULL, "get_ldesc_item() failed to return NULL for NULL item");
 }
 
 // TESTS FOR ADD_ATRR_TO_HASH --------------------------------------------------


### PR DESCRIPTION
Added two functions, get_sdesc_item and get_ldesc_item into item.h and item.c. These functions return the short and long descriptions stored in an item (for issue #202). Also added two tests into test_items.c to test these functions. 
