### PR TITLE
Refactored test files to use the new return value from #245

### DIFF
--- a/src/action_management/src/actionmanagement.c
+++ b/src/action_management/src/actionmanagement.c
@@ -8,7 +8,8 @@
 
 #define BUFFER_SIZE (100)
 #define WRONG_KIND (1)
-#define NOT_ALLOWED (2)
+#define NOT_ALLOWED_DIRECT (2)
+#define NOT_ALLOWED_INDIRECT (3)
 
 
 /* See actionmanagement.h */

--- a/src/action_management/src/actionmanagement.c
+++ b/src/action_management/src/actionmanagement.c
@@ -77,7 +77,7 @@ int do_item_action(game_t *g, action_type_t *a, item_t *i, char **ret_string)
         sprintf(string, "Action %s can't be requested on item %s",
                 a->c_name, i->item_id);
         *ret_string = string;
-        return NOT_ALLOWED;
+        return NOT_ALLOWED_DIRECT;
     }
     /* TODO: implement the rest of this function, using game_state funcs
      * Will perform the action if all checks pass (Sprint 4)
@@ -134,9 +134,10 @@ int do_item_item_action(game_t *g, action_type_t *a, item_t *direct,
     int allowed = allowed_action(direct, a->c_name);
     if (allowed != SUCCESS)
     {
-        sprintf(ret_string, "Action %s can't be requested on item %s",
+        sprintf(string, "Action %s can't be requested on item %s",
                 a->c_name, direct->item_id);
-        return ret_string;
+        *ret_string = string;
+        return NOT_ALLOWED_DIRECT
     }
     // checks if the action can be used on the indirect item
     allowed = allowed_action(indirect, a->c_name);
@@ -144,7 +145,7 @@ int do_item_item_action(game_t *g, action_type_t *a, item_t *direct,
         sprintf(string, "Action %s can't be requested on item %s",
                 a->c_name, indirect->item_id);
         *ret_string = string;
-        return NOT_ALLOWED;
+        return NOT_ALLOWED_INDIRECT;
     }
     /* TODO: implement the rest of this function, using game state funcs
      * Will perform the action if all checks pass (Sprint 4)

--- a/src/action_management/src/actionmanagement.c
+++ b/src/action_management/src/actionmanagement.c
@@ -137,7 +137,7 @@ int do_item_item_action(game_t *g, action_type_t *a, item_t *direct,
         sprintf(string, "Action %s can't be requested on item %s",
                 a->c_name, direct->item_id);
         *ret_string = string;
-        return NOT_ALLOWED_DIRECT
+        return NOT_ALLOWED_DIRECT;
     }
     // checks if the action can be used on the indirect item
     allowed = allowed_action(indirect, a->c_name);

--- a/src/action_management/tests/test_item_actions.c
+++ b/src/action_management/tests/test_item_actions.c
@@ -8,6 +8,8 @@
 #include "player.h"
 
 #define BUFFER_SIZE (100)
+#define WRONG_KIND (1)
+#define NOT_ALLOWED_DIRECT (2)
 
 int execute_do_item_action(char *act_name, enum action_kind kind, char *allowed_act_name, enum action_kind allowed_kind)
 {
@@ -36,7 +38,7 @@ Test(item_actions, correct_kind_1_and_allowed_action)
     int rc = execute_do_item_action("dummy", ITEM, "dummy", ITEM);
 
     cr_assert_eq(rc, SUCCESS,
-                 "execute_do_item_action returned %d for correct kind 1, expected 0", rc);
+                 "execute_do_item_action returned %d for correct kind 1, expected SUCCESS (0)", rc);
 }
 
 Test(item_actions, wrong_kind_2)
@@ -44,30 +46,30 @@ Test(item_actions, wrong_kind_2)
 
     int rc = execute_do_item_action("dummy", PATH, "dummy", PATH);
 
-    cr_assert_eq(rc, FAILURE,
-                 "execute_do_item_action returned %d for wrong kind 2, expected 1", rc);
+    cr_assert_eq(rc, WRONG_KIND,
+                 "execute_do_item_action returned %d for wrong kind 2, expected WRONG_KIND (1)", rc);
 }
 
 Test(item_actions, wrong_kind_3)
 {
     int rc = execute_do_item_action("dummy", ITEM_ITEM, "dummy", ITEM_ITEM);
 
-    cr_assert_eq(rc, FAILURE,
-                 "execute_do_item_action returned %d for wrong kind 3, expected 1", rc);
+    cr_assert_eq(rc, WRONG_KIND,
+                 "execute_do_item_action returned %d for wrong kind 3, expected WRONG_KIND (1)", rc);
 }
 
 Test(item_actions, action_not_allowed_name)
 {
     int rc = execute_do_item_action("dummy", ITEM, "dummy_allow", ITEM);
 
-    cr_assert_eq(rc, 2,
-                 "execute_do_item_action returned %d for action name that is not allowed, expected 2", rc);
+    cr_assert_eq(rc, NOT_ALLOWED_DIRECT,
+                 "execute_do_item_action returned %d for action name that is not allowed, expected NOT_ALLOWED_DIRECT (2)", rc);
 }
 
 Test(item_actions, action_not_allowed_struct)
 {
     int rc = execute_do_item_action("dummy", ITEM, "dummy_allow", ITEM_ITEM);
 
-    cr_assert_eq(rc, 2,
-                 "execute_do_item_action returned %d for action struct that is not allowed, expected 2", rc);
+    cr_assert_eq(rc, NOT_ALLOWED_DIRECT,
+                 "execute_do_item_action returned %d for action struct that is not allowed, expected NOT_ALLOWED_DIRECT (2)", rc);
 }

--- a/src/action_management/tests/test_item_actions.c
+++ b/src/action_management/tests/test_item_actions.c
@@ -20,37 +20,8 @@ int execute_do_item_action(char *act_name, enum action_kind kind, char *allowed_
     item_t *item = item_new("dummy", "The dummy item", "The dummy object of interest");
     add_allowed_action(item, allowed_act_name, allowed_a);
 
-    char *expected_output = malloc(BUFFER_SIZE);
-    sprintf(expected_output, "Requested action %s on item %s",
-            a->c_name, item->item_id);
+    int rc = do_item_action(g, a, item);
 
-    char *kind_error = malloc(BUFFER_SIZE);
-    sprintf(kind_error, "The action type provided is not of the correct kind");
-
-    char *allowed_error = malloc(BUFFER_SIZE);
-    sprintf(allowed_error, "Action %s can't be requested on item %s",
-            a->c_name, item->item_id);
-
-    int rc;
-    if (strcmp(do_item_action(g, a, item), expected_output) == 0)
-    {
-        rc = SUCCESS;
-    }
-    else if (strcmp(do_item_action(g, a, item), kind_error) == 0)
-    {
-        rc = FAILURE;
-    }
-    else if (strcmp(do_item_action(g, a, item), allowed_error) == 0)
-    {
-        rc = 2;
-    }
-    else {
-        rc = 4; //Wrong string printed
-    }
-
-    free(expected_output);
-    free(kind_error);
-    free(allowed_error);
     item_free(item);
     action_type_free(a);
     action_type_free(allowed_a);

--- a/src/action_management/tests/test_item_actions.c
+++ b/src/action_management/tests/test_item_actions.c
@@ -19,8 +19,9 @@ int execute_do_item_action(char *act_name, enum action_kind kind, char *allowed_
     action_type_t *allowed_a = action_type_new(allowed_act_name, allowed_kind);
     item_t *item = item_new("dummy", "The dummy item", "The dummy object of interest");
     add_allowed_action(item, allowed_act_name, allowed_a);
+    char *string = malloc(BUFFER_SIZE);
 
-    int rc = do_item_action(g, a, item);
+    int rc = do_item_action(g, a, item, &string);
 
     item_free(item);
     action_type_free(a);

--- a/src/action_management/tests/test_item_item_actions.c
+++ b/src/action_management/tests/test_item_item_actions.c
@@ -8,6 +8,9 @@
 #include "player.h"
 
 #define BUFFER_SIZE (100)
+#define WRONG_KIND (1)
+#define NOT_ALLOWED_DIRECT (2)
+#define NOT_ALLOWED_INDIRECT (3)
 
 int execute_do_item_item_action(char *act_name, enum action_kind kind, char *allowed_act_name1, enum action_kind allowed_kind1, char *allowed_act_name2, enum action_kind allowed_kind2)
 {
@@ -38,8 +41,8 @@ Test(item_item_actions, wrong_kind_ITEM)
 {
     int rc = execute_do_item_item_action("dummy", ITEM, "dummy", ITEM, "dummy", ITEM);
 
-    cr_assert_eq(rc, FAILURE,
-                 "execute_do_item_item_action returned %d for wrong kind 1, expected 1", rc);
+    cr_assert_eq(rc, WRONG_KIND,
+                 "execute_do_item_item_action returned %d for wrong kind 1, expected WRONG_KIND (1)", rc);
 }
 
 Test(item_item_actions, wrong_kind_PATH)
@@ -47,8 +50,8 @@ Test(item_item_actions, wrong_kind_PATH)
 
     int rc = execute_do_item_item_action("dummy", PATH, "dummy", PATH, "dummy", PATH);
 
-    cr_assert_eq(rc, FAILURE,
-                 "execute_do_item_item_action returned %d for wrong kind 2, expected 1", rc);
+    cr_assert_eq(rc, WRONG_KIND,
+                 "execute_do_item_item_action returned %d for wrong kind 2, expected WRONG_KIND (1)", rc);
     ;
 }
 
@@ -57,7 +60,7 @@ Test(item_item_actions, correct_kind_ITEM_ITEM)
     int rc = execute_do_item_item_action("dummy", ITEM_ITEM, "dummy", ITEM_ITEM, "dummy", ITEM_ITEM);
 
     cr_assert_eq(rc, SUCCESS,
-                 "execute_do_item_item_action returned %d for correct kind 3, expected 1", rc);
+                 "execute_do_item_item_action returned %d for correct kind 3, expected SUCCESS (0)", rc);
 }
 
 Test(item_item_actions, correct_allowed_actions)
@@ -65,29 +68,29 @@ Test(item_item_actions, correct_allowed_actions)
     int rc = execute_do_item_item_action("dummy", ITEM_ITEM, "dummy", ITEM_ITEM, "dummy", ITEM_ITEM);
 
     cr_assert_eq(rc, SUCCESS,
-                 "execute_do_item_item_action returned %d for correct allowed actions in indirect and direct, expected 0", rc);
+                 "execute_do_item_item_action returned %d for correct allowed actions in indirect and direct, expected SUCCESS (0)", rc);
 }
 
 Test(item_item_actions, wrong_allowed_actions_direct)
 {
     int rc = execute_do_item_item_action("dummy", ITEM_ITEM, "dummy_allowed", ITEM_ITEM, "dummy", ITEM_ITEM);
 
-    cr_assert_eq(rc, 2,
-                 "execute_do_item_item_action returned %d for incorrect allowed actions name in direct, expected 2", rc);
+    cr_assert_eq(rc, NOT_ALLOWED_DIRECT,
+                 "execute_do_item_item_action returned %d for incorrect allowed actions name in direct, expected NOT_ALLOWED_DIRECT (2)", rc);
 }
 
 Test(item_item_actions, wrong_allowed_actions_indirect)
 {
     int rc = execute_do_item_item_action("dummy", ITEM_ITEM, "dummy", ITEM_ITEM, "dummy_allowed", ITEM_ITEM);
 
-    cr_assert_eq(rc, 3,
-                 "execute_do_item_item_action returned %d for incorrect allowed actions name in indirect, expected 3", rc);
+    cr_assert_eq(rc, NOT_ALLOWED_INDIRECT,
+                 "execute_do_item_item_action returned %d for incorrect allowed actions name in indirect, expected NOT_ALLOWED_INDIRECT (3)", rc);
 }
 
 Test(item_item_actions, wrong_allowed_actions)
 {
     int rc = execute_do_item_item_action("dummy", ITEM_ITEM, "dummy_allowed", ITEM_ITEM, "dummy_allowed", ITEM_ITEM);
 
-    cr_assert_eq(rc, 2,
-                 "execute_do_item_item_action returned %d for incorrect allowed actions name in indirect and direct, expected 2", rc);
+    cr_assert_eq(rc, NOT_ALLOWED_DIRECT,
+                 "execute_do_item_item_action returned %d for incorrect allowed actions name in indirect and direct, expected NOT_ALLOWED_DIRECT (2)", rc);
 }

--- a/src/action_management/tests/test_item_item_actions.c
+++ b/src/action_management/tests/test_item_item_actions.c
@@ -22,8 +22,9 @@ int execute_do_item_item_action(char *act_name, enum action_kind kind, char *all
     item_t *indirect = item_new("indirect", "The indirect item", "The indirectmost object of interest");
     add_allowed_action(direct, allowed_act_name1, allowed_a1);
     add_allowed_action(indirect, allowed_act_name2, allowed_a2);
+    char *string = malloc(BUFFER_SIZE);
 
-    int rc = do_item_item_action(g, a, direct, indirect);
+    int rc = do_item_item_action(g, a, direct, indirect, &string);
 
     item_free(direct);
     item_free(indirect);

--- a/src/action_management/tests/test_item_item_actions.c
+++ b/src/action_management/tests/test_item_item_actions.c
@@ -23,47 +23,8 @@ int execute_do_item_item_action(char *act_name, enum action_kind kind, char *all
     add_allowed_action(direct, allowed_act_name1, allowed_a1);
     add_allowed_action(indirect, allowed_act_name2, allowed_a2);
 
-    char *expected_output = malloc(BUFFER_SIZE);
-    sprintf(expected_output, "Requested action %s with %s on %s",
-            a->c_name, direct->item_id, indirect->item_id);
+    int rc = do_item_item_action(g, a, direct, indirect);
 
-    char *kind_error = malloc(BUFFER_SIZE);
-    sprintf(kind_error, "The action type provided is not of the correct kind");
-
-    char *allowed_direct_error = malloc(BUFFER_SIZE);
-    sprintf(allowed_direct_error, "Action %s can't be requested on item %s",
-            a->c_name, direct->item_id);
-
-    char *allowed_indirect_error = malloc(BUFFER_SIZE);
-    sprintf(allowed_indirect_error, "Action %s can't be requested on item %s",
-            a->c_name, indirect->item_id);
-
-    int rc;
-    if (strcmp(do_item_item_action(g, a, direct, indirect), expected_output) == 0) 
-    {
-        rc = SUCCESS;
-    }
-    else if (strcmp(do_item_item_action(g, a, direct, indirect), kind_error) == 0)
-    {
-            rc = FAILURE;
-    }
-    else if (strcmp(do_item_item_action(g, a, direct, indirect), allowed_direct_error) == 0)
-    {
-        rc = 2; 
-    }
-    else if (strcmp(do_item_item_action(g, a, direct, indirect), allowed_indirect_error) == 0)
-    {
-        rc = 3;
-    }
-    else
-    {
-        rc = 4; //Wrong string printed
-    }
-
-    free(expected_output);
-    free(kind_error);
-    free(allowed_direct_error);
-    free(allowed_indirect_error);
     item_free(direct);
     item_free(indirect);
     action_type_free(a);

--- a/src/action_management/tests/test_path_actions.c
+++ b/src/action_management/tests/test_path_actions.c
@@ -19,8 +19,9 @@ int execute_do_path_action(char *c_name, enum action_kind kind)
     set_curr_player(g, player);
     action_type_t *a = action_type_new(c_name, kind);
     path_t *p = path_new(dest, direction);
+    char *string = malloc(BUFFER_SIZE);
 
-    int rc = do_path_action(g, a, p);
+    int rc = do_path_action(g, a, p, &string);
     
     path_free(p);
     action_type_free(a);

--- a/src/action_management/tests/test_path_actions.c
+++ b/src/action_management/tests/test_path_actions.c
@@ -20,29 +20,8 @@ int execute_do_path_action(char *c_name, enum action_kind kind)
     action_type_t *a = action_type_new(c_name, kind);
     path_t *p = path_new(dest, direction);
 
-    char *expected_output = malloc(BUFFER_SIZE);
-    sprintf(expected_output, "Requested action %s in direction %s into room %s",
-            a->c_name, p->direction, p->dest->room_id);
-
-    char *kind_error = malloc(BUFFER_SIZE);
-    sprintf(kind_error, "The action type provided is not of the correct kind");
-
-    int rc;
-    if (strcmp(do_path_action(g, a, p), expected_output) == 0)
-    {
-        rc = SUCCESS;
-    }
-    else if (strcmp(do_path_action(g, a, p), kind_error) == 0)
-    {
-        rc = FAILURE;
-    }
-    else
-    {
-        rc = 4; //Wrong string printed
-    }
-
-    free(expected_output);
-    free(kind_error);
+    int rc = do_path_action(g, a, p);
+    
     path_free(p);
     action_type_free(a);
     game_free(g);

--- a/src/action_management/tests/test_path_actions.c
+++ b/src/action_management/tests/test_path_actions.c
@@ -8,6 +8,7 @@
 #include "player.h"
 
 #define BUFFER_SIZE (100)
+#define WRONG_KIND (1)
 
 int execute_do_path_action(char *c_name, enum action_kind kind)
 {
@@ -34,8 +35,8 @@ Test(path_actions, kind_ITEM)
 {
     int rc = execute_do_path_action("dummy", ITEM);
 
-    cr_assert_eq(rc, FAILURE,
-                 "execute_do_item_item_action returned %d for wrong kind ITEM, expected 1", rc);
+    cr_assert_eq(rc, WRONG_KIND,
+                 "execute_do_item_item_action returned %d for wrong kind ITEM, expected WRONG_KIND (1)", rc);
 }
 
 Test(path_actions, kind_PATH)
@@ -44,13 +45,13 @@ Test(path_actions, kind_PATH)
     int rc = execute_do_path_action("dummy", PATH);
 
     cr_assert_eq(rc, SUCCESS,
-                 "execute_do_item_item_action returned %d for correct kind PATH expected 0", rc);
+                 "execute_do_item_item_action returned %d for correct kind PATH expected SUCCESS (0)", rc);
 }
 
 Test(path_actions, kind_ITEM_ITEM)
 {
     int rc = execute_do_path_action("dummy", ITEM_ITEM);
 
-    cr_assert_eq(rc, FAILURE,
-                 "execute_do_item_item_action returned %d for wrong kind ITEM_ITEM expected 1");
+    cr_assert_eq(rc, WRONG_KIND,
+                 "execute_do_item_item_action returned %d for wrong kind ITEM_ITEM expected WRONG_KIND (1)");
 }

--- a/src/cli/src/operations.c
+++ b/src/cli/src/operations.c
@@ -10,9 +10,6 @@
 // remove the comment as soon as checkpointing removes their dummy struct
 //#include "../../checkpointing/include/save.h"
 
-/* Buffer size of 100 determined by action management's buffer size, also of 100*/
-#define BUFFER_SIZE (100)
-
 char *quit_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
 {
     return NULL;
@@ -79,7 +76,7 @@ char *kind1_action_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ct
         {
             action_type_t *action = find_action(tokens[0], table);
 
-            char *str = malloc(BUFFER_SIZE);
+            char *str;
             do_item_action(game, action, curr_item, str);
             printf("%s", str);
             return "The object is found\n";
@@ -101,7 +98,7 @@ char *kind2_action_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ct
         {
             action_type_t *action = find_action(tokens[0], table);
 
-            char *str = malloc(BUFFER_SIZE);
+            char *str;
             do_path_action(game, action, curr_path, str);
             printf("%s", str);
             return "Direction available!\n";
@@ -143,7 +140,7 @@ char *kind3_action_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ct
 
     action_type_t *action = find_action(tokens[0], table);
 
-    char *str = malloc(BUFFER_SIZE);
+    char *str;
     do_item_item_action(game, action, item1, item2, str);
     printf("%s", str);
     return "is an action!";

--- a/src/cli/src/operations.c
+++ b/src/cli/src/operations.c
@@ -77,7 +77,7 @@ char *kind1_action_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ct
             action_type_t *action = find_action(tokens[0], table);
 
             char *str;
-            do_item_action(game, action, curr_item, str);
+            do_item_action(game, action, curr_item, &str);
             printf("%s", str);
             return "The object is found\n";
         }
@@ -96,10 +96,10 @@ char *kind2_action_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ct
     {
         if (strcmp(curr_path->direction,tokens[1]) == 0)
         {
-            action_type_t *action = find_action(tokens[0], table);
+            action_type_t *action = find_action(tokens[0], &table);
 
             char *str;
-            do_path_action(game, action, curr_path, str);
+            do_path_action(game, action, curr_path, &str);
             printf("%s", str);
             return "Direction available!\n";
         }
@@ -141,7 +141,7 @@ char *kind3_action_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ct
     action_type_t *action = find_action(tokens[0], table);
 
     char *str;
-    do_item_item_action(game, action, item1, item2, str);
+    do_item_item_action(game, action, item1, item2, &str);
     printf("%s", str);
     return "is an action!";
 }


### PR DESCRIPTION
Changes:

- Merged with actions/dev
- Added a new macro and changed the name of existing NOT_ALLOWED to differentiate between indirect and direct allowed action errors
- Updated actions/dev version of do_item_item_actions to have new return value and also check allowed_actions of indirect and direct items
- Using the added error code groundwork from #289 actions/dev refactored the test_files to take the new return value

This is the PR for #288 #287 #286.