### PR TITLE
Catching errors occuring when game doesn't exist

### DIFF
--- a/src/cli/examples/testshell.c
+++ b/src/cli/examples/testshell.c
@@ -68,7 +68,7 @@ int main()
         //cmd_free(c);
         free(input);
     }
-    
+
     lookup_t_free(ctx->table);
 
     return 0;

--- a/src/cli/src/cmd.c
+++ b/src/cli/src/cmd.c
@@ -20,9 +20,9 @@ void add_action_entries(lookup_t **table)
 {
     list_action_type_t *all_actions = get_supported_actions();
 
-     while(all_actions != NULL)
-     {
-         action_type_t *curr_action = all_actions->act;
+    while(all_actions != NULL)
+    {
+        action_type_t *curr_action = all_actions->act;
 
         if(curr_action->kind == 1)
         {
@@ -37,92 +37,92 @@ void add_action_entries(lookup_t **table)
             add_entry(curr_action->c_name, kind3_action_operation, table);
         }
 
-         all_actions = all_actions->next;
-     }
- }
+        all_actions = all_actions->next;
+    }
+}
 
- lookup_t *find_entry(char *command_name, lookup_t **table)
- {
-     lookup_t *t;
-     HASH_FIND_STR(*table, command_name, t);
-     return t;
- }
+lookup_t *find_entry(char *command_name, lookup_t **table)
+{
+    lookup_t *t;
+    HASH_FIND_STR(*table, command_name, t);
+    return t;
+}
 
- operation *find_operation(char *command_name, lookup_t **table)
- {
-     lookup_t *t;
-     if((t = find_entry(command_name, table)))
-     {
-         return t->operation_type;
-     }
-     return NULL;
- }
+operation *find_operation(char *command_name, lookup_t **table)
+{
+    lookup_t *t;
+    if((t = find_entry(command_name, table)))
+    {
+        return t->operation_type;
+    }
+    return NULL;
+}
 
- action_type_t *find_action(char *command_name, lookup_t **table)
- {
-     return find_entry(command_name, table)->action;
- }
+action_type_t *find_action(char *command_name, lookup_t **table)
+{
+    return find_entry(command_name, table)->action;
+}
 
- void delete_entry(char *command_name, lookup_t **table)
- {
-     lookup_t *t = find_entry(command_name, table);
-     HASH_DEL(*table, t);
-     free(t);
- }
+void delete_entry(char *command_name, lookup_t **table)
+{
+    lookup_t *t = find_entry(command_name, table);
+    HASH_DEL(*table, t);
+    free(t);
+}
 
- /* === hashtable constructors  === */
+/* === hashtable constructors  === */
 
- /* See cmd.h */
- lookup_t **lookup_t_new()
- {
-     lookup_t **t;
-     int rc;
+/* See cmd.h */
+lookup_t **lookup_t_new()
+{
+    lookup_t **t;
+    int rc;
 
-     t = malloc(sizeof(*t));
+    t = malloc(sizeof(*t));
 
-     if(t == NULL)
-     {
-         return NULL;
-     }
+    if(t == NULL)
+    {
+        return NULL;
+    }
 
-     rc = lookup_t_init(t);
-     if(rc != SUCCESS)
-     {
-         return NULL;
-     }
+    rc = lookup_t_init(t);
+    if(rc != SUCCESS)
+    {
+        return NULL;
+    }
 
-     return t;
- }
+    return t;
+}
 
- /* See cmd.h */
- int lookup_t_init(lookup_t **t)
- {
-     assert(t != NULL);
+/* See cmd.h */
+int lookup_t_init(lookup_t **t)
+{
+    assert(t != NULL);
 
-     add_entry("QUIT", quit_operation, t);
-     add_entry("HELP", help_operation, t);
-     //add_entry("HIST", hist_operation, t);
-     add_entry("LOOK",look_operation, t);
-     add_entry("INV", inventory_operation, t);
-     add_entry("SAVE", save_operation, t);
-     add_entry("MAP", map_operation, t);
-     add_entry("SWITCH", switch_operation, t);
-     add_action_entries(t);
+    add_entry("QUIT", quit_operation, t);
+    add_entry("HELP", help_operation, t);
+    //add_entry("HIST", hist_operation, t);
+    add_entry("LOOK",look_operation, t);
+    add_entry("INV", inventory_operation, t);
+    add_entry("SAVE", save_operation, t);
+    add_entry("MAP", map_operation, t);
+    add_entry("SWITCH", switch_operation, t);
+    add_action_entries(t);
 
-     return SUCCESS;
- }
+    return SUCCESS;
+}
 
- /* See cmd.h */
- void lookup_t_free(lookup_t **t)
- {
-     lookup_t *tmp;
-     lookup_t *current_user;
-     HASH_ITER(hh, *t, current_user, tmp)
-     {
-         HASH_DEL(*t, current_user);
-         free(current_user);
-     }
- }
+/* See cmd.h */
+void lookup_t_free(lookup_t **t)
+{
+    lookup_t *tmp;
+    lookup_t *current_user;
+    HASH_ITER(hh, *t, current_user, tmp)
+    {
+        HASH_DEL(*t, current_user);
+        free(current_user);
+    }
+}
 
 /* === command constructors  === */
 

--- a/src/cli/src/operations.c
+++ b/src/cli/src/operations.c
@@ -43,7 +43,8 @@ char *save_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
 char *look_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
 {
     game_t *game = ctx->game;
-    if(game == NULL || game->curr_room == NULL) return "Room not found! Error! We need a room to be loaded to LOOK!\n";
+    if(game == NULL || game->curr_room == NULL)
+        return "Room not found! Error! We need a room to be loaded to LOOK!\n";
     if(tokens[1] == NULL)
     {
         return game->curr_room->long_desc;

--- a/src/cli/src/operations.c
+++ b/src/cli/src/operations.c
@@ -44,7 +44,9 @@ char *look_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
 {
     game_t *game = ctx->game;
     if(game == NULL || game->curr_room == NULL)
+    {
         return "Room not found! Error! We need a room to be loaded to LOOK!\n";
+    }
     if(tokens[1] == NULL)
     {
         return game->curr_room->long_desc;
@@ -98,7 +100,7 @@ char *kind2_action_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ct
     if(game == NULL || game->curr_room == NULL)
     {
         print_to_cli(ctx, tokens[0]);
-        return ( "Error! We need a loaded room to do the above action. \n");
+        return "Error! We need a loaded room to do the above action. \n";
     }
     lookup_t **table = ctx->table;
 
@@ -125,7 +127,7 @@ char *kind3_action_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ct
     if(game == NULL || game->curr_room == NULL)
     {
         print_to_cli(ctx, tokens[0]);
-        return ( "Error! We need a loaded room to do the above action. \n");
+        return "Error! We need a loaded room to do the above action. \n";
     }
     lookup_t **table = ctx->table;
 

--- a/src/cli/src/operations.c
+++ b/src/cli/src/operations.c
@@ -63,10 +63,11 @@ char *look_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
 char *kind1_action_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
 {
     game_t *game = ctx->game;
-    if(game == NULL || game->curr_room == NULL){
-     print_to_cli(ctx, tokens[0]);
-     return ( "Error! We need a loaded room to do the above action. \n");
-   }
+    if(game == NULL || game->curr_room == NULL)
+    {
+        print_to_cli(ctx, tokens[0]);
+        return ( "Error! We need a loaded room to do the above action. \n");
+    }
     lookup_t **table = ctx->table;
 
     if(tokens[1] == NULL)
@@ -93,10 +94,11 @@ char *kind1_action_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ct
 char *kind2_action_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
 {
     game_t *game = ctx->game;
-    if(game == NULL || game->curr_room == NULL){
-     print_to_cli(ctx, tokens[0]);
-     return ( "Error! We need a loaded room to do the above action. \n");
-   }
+    if(game == NULL || game->curr_room == NULL)
+    {
+        print_to_cli(ctx, tokens[0]);
+        return ( "Error! We need a loaded room to do the above action. \n");
+    }
     lookup_t **table = ctx->table;
 
     path_t *curr_path;
@@ -119,9 +121,10 @@ char *kind2_action_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ct
 char *kind3_action_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
 {
     game_t *game = ctx->game;
-    if(game == NULL || game->curr_room == NULL){
-     print_to_cli(ctx, tokens[0]);
-     return ( "Error! We need a loaded room to do the above action. \n");
+    if(game == NULL || game->curr_room == NULL)
+    {
+        print_to_cli(ctx, tokens[0]);
+        return ( "Error! We need a loaded room to do the above action. \n");
     }
     lookup_t **table = ctx->table;
 
@@ -167,9 +170,10 @@ char *action_error_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ct
 char *inventory_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
 {
     game_t *game = ctx->game;
-    if(game == NULL || game->curr_player == NULL){
-     print_to_cli(ctx, tokens[0]);
-     return "Error! We need a loaded player to check inventory.\n";
+    if(game == NULL || game->curr_player == NULL)
+    {
+        print_to_cli(ctx, tokens[0]);
+        return "Error! We need a loaded player to check inventory.\n";
     }
     item_t *t;
     int i = 0;

--- a/src/cli/src/operations.c
+++ b/src/cli/src/operations.c
@@ -43,7 +43,7 @@ char *save_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
 char *look_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
 {
     game_t *game = ctx->game;
-
+    if(game == NULL || game->curr_room == NULL) return "Room not found! Error! We need a room to be loaded to LOOK!\n";
     if(tokens[1] == NULL)
     {
         return game->curr_room->long_desc;
@@ -63,6 +63,10 @@ char *look_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
 char *kind1_action_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
 {
     game_t *game = ctx->game;
+    if(game == NULL || game->curr_room == NULL){
+     print_to_cli(ctx, tokens[0]);
+     return ( "Error! We need a loaded room to do the above action. \n");
+   }
     lookup_t **table = ctx->table;
 
     if(tokens[1] == NULL)
@@ -89,6 +93,10 @@ char *kind1_action_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ct
 char *kind2_action_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
 {
     game_t *game = ctx->game;
+    if(game == NULL || game->curr_room == NULL){
+     print_to_cli(ctx, tokens[0]);
+     return ( "Error! We need a loaded room to do the above action. \n");
+   }
     lookup_t **table = ctx->table;
 
     path_t *curr_path;
@@ -111,6 +119,10 @@ char *kind2_action_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ct
 char *kind3_action_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
 {
     game_t *game = ctx->game;
+    if(game == NULL || game->curr_room == NULL){
+     print_to_cli(ctx, tokens[0]);
+     return ( "Error! We need a loaded room to do the above action. \n");
+    }
     lookup_t **table = ctx->table;
 
     if(tokens[1] == NULL || tokens[3] == NULL)
@@ -155,7 +167,10 @@ char *action_error_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ct
 char *inventory_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
 {
     game_t *game = ctx->game;
-
+    if(game == NULL || game->curr_player == NULL){
+     print_to_cli(ctx, tokens[0]);
+     return "Error! We need a loaded player to check inventory.\n";
+    }
     item_t *t;
     int i = 0;
     ITER_ALL_ITEMS_IN_INVENTORY(game->curr_player, t)


### PR DESCRIPTION
Issue #310. This is meant to give informative error messages when no game has yet been loaded. Essentially, just adding in tests for when there is no game to access, and error messages to occur instead of segfaults.

Files have been tweaked in operations.c in order to insert the messages.