### PR TITLE
PR from wdl/create_yaml to wdl/dev for sample.yaml example file 

### DIFF
--- a/src/wdl/examples/sample_yaml/sample.yaml
+++ b/src/wdl/examples/sample_yaml/sample.yaml
@@ -1,0 +1,48 @@
+#
+# Sample proof-of-concept yaml file
+#
+
+GAME:
+ - start: "room A"
+   intro: "This is the intro"
+   end: "room B"
+
+ROOMS:
+ - id: "room A"
+   short_desc: "This is room A"
+   long_desc: "This is room A long"
+   connection: 
+    - to: "room B"
+      direction: "south"
+
+ - id: "room B"
+   short_desc: "This is room B"
+   long_desc: "This is room B long"
+   connection: 
+    - to: "room A"
+      direction: "west"
+
+ - id: "room C"
+   short_desc: "This is room C"
+   long_desc: "This is room C long"
+   connection: 
+    - to: "room A"
+      direction: "north"
+
+ITEMS:
+ - id: "chair"
+   short_desc: "This is a chair"
+   long_desc: "This is a chair long"
+   in: "room A"
+   actions: 
+    - action: "PUSH"
+    - action: "PULL" 
+
+
+ - id: "table"
+   short_desc: "This is a table"
+   long_desc: "This is a table long"
+   in: "room B"
+   actions:
+    - action: "PUSH"
+    - action: "PULL"

--- a/src/wdl/examples/sample_yaml/sample.yaml
+++ b/src/wdl/examples/sample_yaml/sample.yaml
@@ -78,6 +78,8 @@ ITEMS:
       - id: "lever"
         attribute: "pulled"
         value: "no"
+      text_success: "Congrats! You can now access room B."
+      text_fail: "You cannot push the table. You can only pull it."
     - action: "PULL"
       conditions:
       - id: "star"
@@ -87,6 +89,8 @@ ITEMS:
       - id: "lever"
         attribute: "pulled"
         value: "no"
+      text_success: "Congrats! You can now access room C."
+      text_fail: "You cannot pull the table if the star is not green."
         
  - id: "star"
    short_desc: "This is a star"

--- a/src/wdl/examples/sample_yaml/sample.yaml
+++ b/src/wdl/examples/sample_yaml/sample.yaml
@@ -87,10 +87,12 @@ ITEMS:
       - id: "lever"
         attribute: "pulled"
         value: "no"
+        
  - id: "star"
    short_desc: "This is a star"
    long_desc: "This is a star long"
    in: "room B"
+
  - id: "lever"
    short_desc: "This is a table"
    long_desc: "This is a table long"

--- a/src/wdl/examples/sample_yaml/sample.yaml
+++ b/src/wdl/examples/sample_yaml/sample.yaml
@@ -36,6 +36,7 @@ ITEMS:
    in: "room A"
    actions: 
     - action: "PUSH"
+      - conditions:
     - action: "PULL" 
 
 

--- a/src/wdl/examples/sample_yaml/sample.yaml
+++ b/src/wdl/examples/sample_yaml/sample.yaml
@@ -34,16 +34,64 @@ ITEMS:
    short_desc: "This is a chair"
    long_desc: "This is a chair long"
    in: "room A"
+   attributes:
+    - attribute: "size"
+      value: "small"
+    - attribute: "color"
+      value: "black"
    actions: 
     - action: "PUSH"
-      - conditions:
+      conditions:
+      - id: "star"
+        attribute: "color"
+        value: "red"
+      effects:
+      - id: "lever"
+        attribute: "pulled"
+        value: "yes"
     - action: "PULL" 
-
+      conditions:
+      - id: "star"
+        attribute: "color"
+        value: "green"
+      effects:
+      - id: "lever"
+        attribute: "pulled"
+        value: "no"
 
  - id: "table"
    short_desc: "This is a table"
    long_desc: "This is a table long"
    in: "room B"
+   attributes:
+    - attribute: "width"
+      value: "100"
+    - attribute: "color"
+      value: "green"
    actions:
     - action: "PUSH"
+      conditions:
+      - id: "star"
+        attribute: "color"
+        value: "green"
+      effects:
+      - id: "lever"
+        attribute: "pulled"
+        value: "no"
     - action: "PULL"
+      conditions:
+      - id: "star"
+        attribute: "color"
+        value: "green"
+      effects:
+      - id: "lever"
+        attribute: "pulled"
+        value: "no"
+ - id: "star"
+   short_desc: "This is a star"
+   long_desc: "This is a star long"
+   in: "room B"
+ - id: "lever"
+   short_desc: "This is a table"
+   long_desc: "This is a table long"
+   in: "room B"

--- a/src/wdl/examples/sample_yaml/sample.yaml
+++ b/src/wdl/examples/sample_yaml/sample.yaml
@@ -58,6 +58,8 @@ ITEMS:
       - id: "lever"
         attribute: "pulled"
         value: "no"
+   text_success: "<placeholder text>"
+   text_fail: "<placeholder text>"
 
  - id: "table"
    short_desc: "This is a table"
@@ -96,8 +98,14 @@ ITEMS:
    short_desc: "This is a star"
    long_desc: "This is a star long"
    in: "room B"
+   text_success: "<placeholder text>"
+   text_fail: "<placeholder text>"
 
  - id: "lever"
    short_desc: "This is a table"
    long_desc: "This is a table long"
    in: "room B"
+   attributes:
+   actions:
+   text_success: "<placeholder text>"
+   text_fail: "<placeholder text>"

--- a/src/wdl/examples/sample_yaml/sample.yaml
+++ b/src/wdl/examples/sample_yaml/sample.yaml
@@ -58,8 +58,8 @@ ITEMS:
       - id: "lever"
         attribute: "pulled"
         value: "no"
-   text_success: "<placeholder text>"
-   text_fail: "<placeholder text>"
+   text_success: ""
+   text_fail: ""
 
  - id: "table"
    short_desc: "This is a table"
@@ -98,8 +98,10 @@ ITEMS:
    short_desc: "This is a star"
    long_desc: "This is a star long"
    in: "room B"
-   text_success: "<placeholder text>"
-   text_fail: "<placeholder text>"
+   attributes:
+   actions:
+   text_success: ""
+   text_fail: ""
 
  - id: "lever"
    short_desc: "This is a table"
@@ -107,5 +109,5 @@ ITEMS:
    in: "room B"
    attributes:
    actions:
-   text_success: "<placeholder text>"
-   text_fail: "<placeholder text>"
+   text_success: ""
+   text_fail: ""

--- a/src/wdl/include/load_room.h
+++ b/src/wdl/include/load_room.h
@@ -14,6 +14,11 @@
 #include "game.h"
 #include "validate.h"
 #include "parse.h"
+#include "common.h"
+
+#define PATH_FAILURE (1)
+#define ID_FAILURE (2)
+#define CONNECTIONS_FAILURE (3)
 
 #define ROOM_PATH "../examples/sample_yaml/connected_rooms.yaml"
 

--- a/src/wdl/src/load_room.c
+++ b/src/wdl/src/load_room.c
@@ -15,7 +15,7 @@ int add_rooms_to_game(obj_t *doc, game_t *g)
     // if rooms list is empty then return 1
     if (curr == NULL) {
         fprintf(stderr, "rooms list is empty\n");
-        return 1;
+        return FAILURE;
     }
 
     // while list of rooms exists, create new game_struct room, add room to game
@@ -33,7 +33,7 @@ int add_rooms_to_game(obj_t *doc, game_t *g)
         curr = curr->next;
     }
 
-    return 0;
+    return SUCCESS;
 }
 
 /* see load_rooms.h */
@@ -48,7 +48,7 @@ int add_connections_to_rooms(obj_t *doc, game_t *g)
     // if rooms list is empty then return 1
     if (curr == NULL) {
         fprintf(stderr, "rooms list is empty\n");
-        return 1;
+        return FAILURE;
     }
 
     // while list of rooms exists, create new game_struct room, add room to game
@@ -61,7 +61,7 @@ int add_connections_to_rooms(obj_t *doc, game_t *g)
         // if connections list is empty then return 1
         if (conn_curr == NULL) {
             fprintf(stderr, "connections list is empty\n");
-            return 1;
+            return FAILURE;
         }
         // iterate through connections list
         while (conn_curr != NULL) {
@@ -74,19 +74,19 @@ int add_connections_to_rooms(obj_t *doc, game_t *g)
 
             // if result is 1, then id doesn't exist, if result is 2, then
             // connection id (to) doesn't exist
-            if (result == 1) {
+            if (result == PATH_FAILURE) {
                 fprintf(stderr, "add_path failed\n");
-                return 1;
+                return FAILURE;
             }
-            else if (result == 2) {
+            else if (result == ID_FAILURE) {
                 fprintf(stderr, "the source room with id %s does not exist\n",
                         id);
-                return 2;
+                return FAILURE;
             }
-            else if (result == 3) {
+            else if (result == CONNECTIONS_FAILURE) {
                 fprintf(stderr, "the connection room with id %s does not exist\n",
                         to);
-                return 3;
+                return FAILURE;
             }
             else {
                 printf("the connection between %s and %s in the direction %s"
@@ -99,5 +99,5 @@ int add_connections_to_rooms(obj_t *doc, game_t *g)
         curr = curr->next;
     }
 
-    return 0;
+    return SUCCESS;
 }


### PR DESCRIPTION
This is a pull request to merge the new sample.yaml file into wdl/dev. This is a game that can be parsed by and loaded into game-state structures using the libobj and libwdl functions. It contains the following fields which were not properly streamlined across the previous example files:
- attributes
- associated attribute values
- conditions (id, attribute, value)
- effects (id, attribute, value)
- text_fail
- text_success

The FILE_PATH macro will be modified to reference this file in the wdl_common.h file once this PR has been approved to dev.

This PR also includes streamlining current macro definitions for failure, as game-state requested that these be abstracted away using macros instead of direct integer values.