### PR TITLE
PR from wdl/correct-attribute to wdl/dev to load attributes fields and values into game-state structures

### DIFF
--- a/src/wdl/include/parse.h
+++ b/src/wdl/include/parse.h
@@ -47,4 +47,17 @@ attr_list_t* get_items_in_room(char* room_id, attr_list_t* all_items);
  */
 attr_list_t *get_item_actions(obj_t *item);
 
+/*
+ * get_item_attributes()
+ * gets a list of attributes assoiciated with a given item
+ *
+ * parameters:
+ *  - item: the item for which to get the attributes
+ *
+ * returns:
+ *  - a linked list of attributes
+ *  - a null if no attributes are present
+ */
+attr_list_t *get_item_attributes(obj_t *item);
+
 #endif /* INCLUDE_PARSE_H */

--- a/src/wdl/src/load_item.c
+++ b/src/wdl/src/load_item.c
@@ -86,6 +86,17 @@ int load_items(obj_t *doc, game_t *g)
         /* in parameter yet to implemented by game-state
         item_t *item = item_new(id, short_desc, long_desc, in); */
 
+        //load attributes into item
+        // getting a list of actions from item
+        attr_list_t *attr_ls = get_item_attributes(doc);
+        while (attr_ls != NULL)
+        {
+            char* attr_name = obj_get_str(attr_ls->obj, "attribute");
+            char* val = obj_get_str(attr_ls->obj, "value");
+            set_str_attr(item, attr_name, val);
+            attr_ls = attr_ls->next;
+        }
+        
         //load actions into item
         if(load_actions(curr->obj, item) == -1)
 	      {

--- a/src/wdl/src/parse.c
+++ b/src/wdl/src/parse.c
@@ -99,3 +99,13 @@ attr_list_t *get_item_actions(obj_t *item)
         return NULL;
     }
 }
+
+/* see parse.c */
+attr_list_t *get_item_attributes(obj_t *item)
+{
+    attr_list_t *ls = obj_list_attr(obj_get_attr(item, "attributes", false));
+    if (ls == NULL) {
+        return NULL;
+    }
+    return ls;
+}

--- a/src/wdl/tests/test_item.c
+++ b/src/wdl/tests/test_item.c
@@ -3,6 +3,24 @@
 #include <stdbool.h>
 #include "load_item.h"
 
+/* see item.h */
+char *get_sdesc_item(item_t *item)
+{
+  if (item == NULL) {
+    return NULL;
+  }
+  return item->short_desc;
+}
+
+/* see item.h */
+char *get_ldesc_item(item_t *item)
+{
+  if (item == NULL) {
+    return NULL;
+  }
+  return item->long_desc;
+}
+
 void item_check(char *room, char *item, char *index)
 {
     obj_t *doc = get_doc_obj(FILE_PATH);

--- a/src/wdl/tests/test_item.c
+++ b/src/wdl/tests/test_item.c
@@ -3,24 +3,6 @@
 #include <stdbool.h>
 #include "load_item.h"
 
-/* see item.h */
-char *get_sdesc_item(item_t *item)
-{
-  if (item == NULL) {
-    return NULL;
-  }
-  return item->short_desc;
-}
-
-/* see item.h */
-char *get_ldesc_item(item_t *item)
-{
-  if (item == NULL) {
-    return NULL;
-  }
-  return item->long_desc;
-}
-
 void item_check(char *room, char *item, char *index)
 {
     obj_t *doc = get_doc_obj(FILE_PATH);


### PR DESCRIPTION
This is a pull request to load attributes into the structures provided by the game-state team. In order to complete this, I created a while loop to iterate over the attributes within the attribute list from the document. I also added a function to the parse module to retrieve the attributes associated with a given item. More thorough integration tests will be written once this PR has been approved.