### PR TITLE
Updated Makefiles to avoid generating .d files when running 'make clean'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,15 @@ language: c
 
 compiler: gcc
 
+before_script:
+  - make clean
+
 script:
   - make
   - cd src/game-state/
   - make tests
   - tests/test-libgamestate
   - cd ../../
+
+after_script:
+  - make clean

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 CC = gcc
 AR = ar
-CFLAGS = -fPIC -Wall -Wextra -O2 -g -I./include/ -I./src/common/include -I./src/game-state/include -I./src/ui/include -I./src/cli/include -I./src/action_management/include
+CFLAGS = -MMD -fPIC -Wall -Wextra -O2 -g -I./include/ -I./src/common/include -I./src/game-state/include -I./src/ui/include -I./src/cli/include -I./src/action_management/include
 RM = rm -f
 LDLIBS = -lyaml -lncursesw -lreadline
 BIN = chiventure
@@ -34,9 +34,6 @@ $(LIBS):
 
 SRCS = src/chiventure.c
 OBJS = $(SRCS:.c=.o)
-
-$(SRCS:.c=.d):%.d:%.c
-	$(CC) $(CFLAGS) -MM $< -MT $(patsubst %.d,%.o,$@) > $@
 
 -include $(SRCS:.c=.d)
 

--- a/src/action_management/Makefile
+++ b/src/action_management/Makefile
@@ -5,7 +5,7 @@
 CC = gcc
 AR = ar
 SRCS = src/actionmanagement.c src/get_actions.c 
-CFLAGS = -Wall -Wextra -O2 -g -I./include/ -I../common/include/ -I../game-state/include/ -I../cli/include/ -I../ui/include/ -I../checkpointing/include -I../action-management/include
+CFLAGS = -MMD -Wall -Wextra -O2 -g -I./include/ -I../common/include/ -I../game-state/include/ -I../cli/include/ -I../ui/include/ -I../checkpointing/include -I../action-management/include
 OBJS = $(SRCS:.c=.o)
 LIB = action_management.a
 RM = rm -f
@@ -15,9 +15,6 @@ all: $(LIB)
 
 $(LIB): $(OBJS)
 	$(AR) rcs $@ $^ 
-
-$(SRCS:.c=.d):%.d:%.c
-	$(CC) $(CFLAGS) -MM $< -MT $(patsubst %.d,%.o,$@) > $@
 
 -include $(SRCS:.c=.d)
 

--- a/src/action_management/tests/Makefile
+++ b/src/action_management/tests/Makefile
@@ -1,7 +1,7 @@
 # Makefile based on template at https://gist.github.com/xuhdev/1873316
 
 CC = gcc 
-CFLAGS = -fPIC -Wall -Wextra -O2 -g -I ../include/ -I ../../common/include/ -I ../../game-state/include -I ../../ui/include -I ../../cli/include
+CFLAGS = -MMD -fPIC -Wall -Wextra -O2 -g -I ../include/ -I ../../common/include/ -I ../../game-state/include -I ../../ui/include -I ../../cli/include
 LFLAGS = -L .. -L ../../common -L ../../game-state -L ../../ui -L ../../cli
 RM = rm -f
 BIN = test-actionmanagement
@@ -15,9 +15,6 @@ all: $(BIN)
 
 $(BIN): $(OBJS)
 	$(CC) -o $@ $(OBJS) $(LFLAGS) $(LIBS) 
-
-$(SRCS:.c=.d):%.d:%.c
-	$(CC) $(CFLAGS) -MM $< >$@
 
 .PHONY: clean
 clean:

--- a/src/cli/Makefile
+++ b/src/cli/Makefile
@@ -2,7 +2,7 @@
 
 CC = gcc
 SRCS = src/cmd.c src/shell.c src/parser.c src/operations.c 
-CFLAGS = -fPIC -Wall -Wextra -O2 -g -I./include/ -I../common/include/ -I../game-state/include/ -I../action_management/include/ -I../ui/include/
+CFLAGS = -MMD -fPIC -Wall -Wextra -O2 -g -I./include/ -I../common/include/ -I../game-state/include/ -I../action_management/include/ -I../ui/include/
 OBJS = $(SRCS:.c=.o)
 LIB = cli.a
 RM = rm -f
@@ -12,9 +12,6 @@ all: $(LIB)
 
 $(LIB): $(OBJS)
 	ar -r -o $@ $(OBJS)
-
-$(SRCS:.c=.d):%.d:%.c
-	$(CC) $(CFLAGS) -MM $< -MT $(patsubst %.d,%.o,$@) > $@
 
 -include $(SRCS:.c=.d)
 

--- a/src/cli/examples/Makefile
+++ b/src/cli/examples/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -fPIC -Wall -Wextra -O2 -g -I../include/ -I../../common/include/ -I../../game-state/include/ -I../../action_management/include/ -I../../ui/include
+CFLAGS = -MMD -fPIC -Wall -Wextra -O2 -g -I../include/ -I../../common/include/ -I../../game-state/include/ -I../../action_management/include/ -I../../ui/include
 
 RM = rm -f
 LDLIBS = -lreadline 
@@ -21,10 +21,7 @@ all: ${BIN}
 $(BIN): $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) $(LDLIBS) $(STLIBS) -o$(BIN)
 
-$(SRCS:.c=.d):%.d:%.c
-	$(CC) $(CFLAGS) -MM $< >$@
-
-include $(SRCS:.c=.d)
+-include $(SRCS:.c=.d)
 
 .PHONY: clean
 clean:

--- a/src/cli/tests/Makefile
+++ b/src/cli/tests/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -fPIC -Wall -Wextra -O2 -g -I../include/ -I../../common/include/ -I../../game-state/include/ -I../../action_management/include/ -I../../ui/include/
+CFLAGS = -MMD -fPIC -Wall -Wextra -O2 -g -I../include/ -I../../common/include/ -I../../game-state/include/ -I../../action_management/include/ -I../../ui/include/
 RM = rm -f
 LDLIBS = -lcriterion 
 

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -2,7 +2,7 @@
 
 CC = gcc
 AR = ar
-CFLAGS = -fPIC -Wall -Wextra -O2 -g -I./include/ -I../game-state/include/ -I../ui/include/ -I../cli/include/ -I../action_management/include/
+CFLAGS = -MMD -fPIC -Wall -Wextra -O2 -g -I./include/ -I../game-state/include/ -I../ui/include/ -I../cli/include/ -I../action_management/include/
 RM = rm -f
 LIB = common.a
 
@@ -14,9 +14,6 @@ all: $(LIB)
 
 SRCS = src/ctx.c src/sample_game.c 
 OBJS = $(SRCS:.c=.o)
-
-$(SRCS:.c=.d):%.d:%.c
-	$(CC) $(CFLAGS) -MM $< -MT $(patsubst %.d,%.o,$@) > $@
 
 -include $(SRCS:.c=.d)
 

--- a/src/libobj/Makefile
+++ b/src/libobj/Makefile
@@ -2,7 +2,7 @@
 
 CC = gcc
 AR = ar 
-CFLAGS = -fPIC -Wall -Wextra -O2 -g -I./include/ -I../common/include/
+CFLAGS = -MMD -fPIC -Wall -Wextra -O2 -g -I./include/ -I../common/include/
 RM = rm -f
 LIB = libobj.a
 LDLIBS = -lyaml
@@ -16,9 +16,6 @@ all: $(LIB)
 SRCS = src/obj.c src/parser.c src/stack.c
 OBJS = $(SRCS:.c=.o)
 
-$(SRCS:.c=.d):%.d:%.c
-	$(CC) $(CFLAGS) -MM $< -MT $(patsubst %.d,%.o,$@) > $@
-
 -include $(SRCS:.c=.d)
 
 $(LIB): $(OBJS)
@@ -29,9 +26,6 @@ $(LIB): $(OBJS)
 
 EXAMPLE_BINS = examples/obj examples/parse
 EXAMPLE_SRCS=$(patsubst %, %.c, $(EXAMPLE_BINS))
-
-$(EXAMPLE_SRCS:.c=.d):%.d:%.c
-	$(CC) $(CFLAGS) -MM $< -MT $(patsubst %.d,%.o,$@) > $@
 
 -include $(EXAMPLE_SRCS:.c=.d)
 

--- a/src/ui/Makefile
+++ b/src/ui/Makefile
@@ -2,7 +2,7 @@
 
 CC = gcc
 AR = ar
-CFLAGS = -fPIC -Wall -Wextra -O2 -g -I./include/ -I../common/include/ -I../game-state/include/ -I../cli/include/ -I../action_management/include/
+CFLAGS = -MMD -fPIC -Wall -Wextra -O2 -g -I./include/ -I../common/include/ -I../game-state/include/ -I../cli/include/ -I../action_management/include/
 RM = rm -f
 LIB = ui.a
 LDLIBS = -lncursesw -lreadline
@@ -25,9 +25,6 @@ SRCS = src/ui.c src/window.c src/print_functions.c src/coordinate.c src/DFS.c sr
 OBJS = $(SRCS:.c=.o)
 LOGS = examples/ui_debug.txt
 
-$(SRCS:.c=.d):%.d:%.c
-	$(CC) $(CFLAGS) -MM $< -MT $(patsubst %.d,%.o,$@) > $@
-
 -include $(SRCS:.c=.d)
 
 $(LIB): $(OBJS)
@@ -41,9 +38,6 @@ $(LIB): $(OBJS)
 EXAMPLE_BINS = examples/map_example examples/coord_example examples/test_ui
 
 EXAMPLE_SRCS=$(patsubst %, %.c, $(EXAMPLE_BINS))
-
-$(EXAMPLE_SRCS:.c=.d):%.d:%.c
-	$(CC) $(CFLAGS) -MM $< -MT $(patsubst %.d,%.o,$@) > $@
 
 -include $(EXAMPLE_SRCS:.c=.d)
 

--- a/src/ui/tests/Makefile
+++ b/src/ui/tests/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -fPIC -Wall -Wextra -O2 -g -I../include/ -I../../common/include/ -I../../game-state/include/ -I../../cli/include/ -I../../action_management/include/
+CFLAGS = -MMD -fPIC -Wall -Wextra -O2 -g -I../include/ -I../../common/include/ -I../../game-state/include/ -I../../cli/include/ -I../../action_management/include/
 UI = -L../. -Wl,-rpath,../.
 COMMON = -L../../common/ -Wl,-rpath,../../common/ -l:common.a
 CLI = -L../../cli/ -Wl,-rpath,../../cli/ -l:cli.a
@@ -19,11 +19,7 @@ all: ${BIN}
 $(BIN): $(OBJS)
 	$(CC) $(OBJS) -o$(BIN) $(STLIBS) $(LDLIBS)
 
-
-$(SRCS:.c=.d):%.d:%.c
-	$(CC) $(CFLAGS) -MM $< >$@
-
-include $(SRCS:.c=.d)
+-include $(SRCS:.c=.d)
 
 .PHONY: clean
 clean:

--- a/src/wdl/Makefile
+++ b/src/wdl/Makefile
@@ -2,7 +2,7 @@
 
 CC = gcc
 AR = ar
-CFLAGS = -fPIC -Wall -Wextra -O2 -g -I./include/ -I../libobj/include/ -I../game-state/include/ -I../action_management/include/ -I../common/include/ -I../ui/include -I../cli/include -I../checkpointing/include
+CFLAGS = -MMD -fPIC -Wall -Wextra -O2 -g -I./include/ -I../libobj/include/ -I../game-state/include/ -I../action_management/include/ -I../common/include/ -I../ui/include -I../cli/include -I../checkpointing/include
 RM = rm -f
 LIB = wdl.a
 LDFLAGS = -L../libobj -L../action_management
@@ -21,9 +21,6 @@ all: $(LIB)
 SRCS = src/parse.c src/validate.c src/load_room.c src/load_item.c src/load_game.c
 OBJS = $(SRCS:.c=.o)
 
-$(SRCS:.c=.d):%.d:%.c
-	$(CC) $(CFLAGS) -MM $< -MT $(patsubst %.d,%.o,$@) > $@
-
 -include $(SRCS:.c=.d)
 
 $(LIB): $(OBJS)
@@ -36,9 +33,6 @@ clean-lib:
 
 EXAMPLE_BINS = examples/typecheck_demo
 EXAMPLE_SRCS=$(patsubst %, %.c, $(EXAMPLE_BINS))
-
-$(EXAMPLE_SRCS:.c=.d):%.d:%.c
-	$(CC) $(CFLAGS) -MM $< -MT $(patsubst %.d,%.o,$@) > $@
 
 -include $(EXAMPLE_SRCS:.c=.d)
 

--- a/src/wdl/tests/Makefile
+++ b/src/wdl/tests/Makefile
@@ -1,6 +1,6 @@
 #Makefile for Tests
 CC = gcc 
-CFLAGS = -fPIC -Wall -Wextra -O2 -g -I../../game-state/include/ -I../include/ -I../../action_management/include/ -I../../libobj/include -I../../common/include
+CFLAGS = -MMD -fPIC -Wall -Wextra -O2 -g -I../../game-state/include/ -I../include/ -I../../action_management/include/ -I../../libobj/include -I../../common/include
 LDFLAGS = -L../ -L../../libobj -L../../game-state -L../../action_management
 LDLIBS = ../wdl.a ../../libobj/libobj.a ../../game-state/game-state.a ../../action_management/action_management.a -lyaml -lcriterion
 RM = rm -f
@@ -16,10 +16,7 @@ all: ${BIN}
 $(BIN): $(OBJS)
 	$(CC) $(LDFLAGS) $(OBJS) -o$(BIN) $(LDLIBS) 
 
-$(SRCS:.c=.d):%.d:%.c
-	$(CC) $(CFLAGS) -MM $< >$@
-
-include $(SRCS:.c=.d)
+-include $(SRCS:.c=.d)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
One of the pervasive issues with the Makefiles is that "make clean" actually results in invoking gcc to generate dependency files, instead of just calling "rm". This patch should address that issue.