### PR TITLE
Correcting inputs in add_action call in sample_game.c

### DIFF
--- a/src/common/src/sample_game.c
+++ b/src/common/src/sample_game.c
@@ -51,13 +51,13 @@ game_t* create_sample_game()
     /* add valid actions to each item */
     // NOTE: I based this off *NEW* code from game-state/develop-actions
     // it will not work in this branch because develop-actions is not merged
-    add_action(item_orb, "TAKE", actiontype_take, 
+    add_action(item_orb, "TAKE", 
                "You have placed the orb in your pocket.", "Can't perform that action!");
-    add_action(item_orb, "DROP", actiontype_drop,
+    add_action(item_orb, "DROP",
                "You have dropped the orb.", "Can't perform that action!");
-    add_action(item_orb, "PUT_ON", actiontype_puton,
+    add_action(item_orb, "PUT_ON",
                "You have placed the orb on the table", "Can't perform that action!");
-    add_action(item_table, "PUT_ON", actiontype_puton,
+    add_action(item_table, "PUT_ON",
                 "You have placed the orb on the table", "Can't perform that action!");
 
     /* add items to room */


### PR DESCRIPTION
This PR is to correct the add_action calls in the most recent action-management PR #353 (that I approved so this is my bad). Add_action, which is not yet in master, no longer takes in the action_type_t struct.

These changes should allow the #335 game-state PR to build.