### PR TITLE
Fix seg faults in game_action_new()

### DIFF
--- a/src/game-state/include/game_state_common.h
+++ b/src/game-state/include/game_state_common.h
@@ -14,15 +14,16 @@
 #define MAX_ID_LEN 20
 #define MAX_SDESC_LEN 50
 #define MAX_LDESC_LEN 300
+#define MAX_MSG_LEN 300
 #define MAX_START_DESC_LEN 500 // for string in game struct
 #define HASH_SIZE 500 // temporary hash table size for testing item fxns
 
 //Macros for move_room()
 #define GAME_NULL 2
 #define ROOM_NULL 3
-#define FINAL_ROOM 4 
+#define FINAL_ROOM 4
 
-//Macros for game_action_t functions 
+//Macros for game_action_t functions
 #define ITEM_SRC_NULL 2
 #define ITEM_MODIFY_NULL 3
 #define ACTION_NULL 4

--- a/src/game-state/src/game_action.c
+++ b/src/game-state/src/game_action.c
@@ -3,7 +3,7 @@
 #include "common-game-action.h"
 
 /* See common_game_action.h */
-int game_action_init(game_action_t *new_action, char *act_name, 
+int game_action_init(game_action_t *new_action, char *act_name,
 		     char* success_str, char* fail_str) {
     assert(new_action != NULL);
 
@@ -21,6 +21,8 @@ int game_action_init(game_action_t *new_action, char *act_name,
 game_action_t *game_action_new(char *action_name, char* success_str, char* fail_str) {
     game_action_t *new_action = malloc(sizeof(game_action_t));
     new_action->action_name = malloc(MAX_ID_LEN * sizeof(char));
+    new_action->success_str = malloc(MAX_MSG_LEN * sizeof(char));
+    new_action->fail_str = malloc(MAX_MSG_LEN * sizeof(char));
 
     int check = game_action_init(new_action, action_name, success_str, fail_str);
 


### PR DESCRIPTION
CLI reported a bug of our game-state:
the add_action function causes a segfault in create_sample_game
`strncpy(new_action->action_name, act_name, strlen(act_name));`

this line in game init causes the seg fault

Changes:
In game_action_init(), malloc a size of MAX_MSG_LEN (300) to action->success_str and action->fail_str before strncpy() 