### PR TITLE
Emergency fix for name command

### DIFF
--- a/src/ui/src/print_functions.c
+++ b/src/ui/src/print_functions.c
@@ -126,9 +126,9 @@ void print_cli(chiventure_ctx_t *ctx, window_t *win)
         do_cmd(c, &quit, ctx);
     }
 
-    if (cmd_string) {
-        free(cmd_string);
-    }
+    // if (cmd_string) {
+    //     free(cmd_string);
+    // }
 
     getyx(win->w, y, x);
 

--- a/src/ui/src/print_functions.c
+++ b/src/ui/src/print_functions.c
@@ -126,10 +126,6 @@ void print_cli(chiventure_ctx_t *ctx, window_t *win)
         do_cmd(c, &quit, ctx);
     }
 
-    // if (cmd_string) {
-    //     free(cmd_string);
-    // }
-
     getyx(win->w, y, x);
 
     // scrolls the screen up if there is no space to print the next line


### PR DESCRIPTION
The string I needed was freed for no particular reason. It should still be in use.