### PR TITLE
fixed* memory leak

### DIFF
--- a/src/cli/src/cmd.c
+++ b/src/cli/src/cmd.c
@@ -10,7 +10,9 @@
 void add_entry(char *command_name, operation *associated_operation, action_type_t *action, lookup_t **table)
 {
     lookup_t *t = malloc(sizeof(lookup_t));
-    t->name = command_name;
+    char * newname = malloc(sizeof(char) * strlen(command_name));
+    strcpy(newname, command_name);
+    t->name = new_name;
     t->operation_type = associated_operation;
     t->action = action;
     HASH_ADD_KEYPTR(hh, *table, t->name, strlen(t->name), t);
@@ -127,6 +129,7 @@ int lookup_t_free(lookup_t **t)
     HASH_ITER(hh, *t, current_user, tmp)
     {
         HASH_DEL(*t, current_user);
+        free(current_user->name);
         free(current_user);
     }
     return SUCCESS;

--- a/src/cli/src/cmd.c
+++ b/src/cli/src/cmd.c
@@ -14,7 +14,7 @@
 void add_entry(char *command_name, operation *associated_operation, action_type_t *action, lookup_t **table)
 {
     lookup_t *t = malloc(sizeof(lookup_t));
-    char * newname = malloc(sizeof(char) * strlen(command_name));
+    char *newname = malloc(sizeof(char) * strlen(command_name));
     strcpy(newname, command_name);
     t->name = newname;
     t->operation_type = associated_operation;

--- a/src/cli/src/cmd.c
+++ b/src/cli/src/cmd.c
@@ -12,7 +12,7 @@ void add_entry(char *command_name, operation *associated_operation, action_type_
     lookup_t *t = malloc(sizeof(lookup_t));
     char * newname = malloc(sizeof(char) * strlen(command_name));
     strcpy(newname, command_name);
-    t->name = new_name;
+    t->name = newname;
     t->operation_type = associated_operation;
     t->action = action;
     HASH_ADD_KEYPTR(hh, *table, t->name, strlen(t->name), t);

--- a/src/cli/src/operations.c
+++ b/src/cli/src/operations.c
@@ -51,7 +51,7 @@ char *load_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
   }
   else
     return "Improper filename, Load failed\n";
-  
+
 }
 
 bool validate_filename(char *filename)
@@ -276,6 +276,8 @@ char *name_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
     {
         return "You can't change the meaning of a word that's already defined!";
     }
+    char * newname = malloc(sizeof(char) * strlen(tokens[2]));
+    strcpy(newname, tokens[2]);
     add_entry(tokens[2],(find_operation(tokens[1],(ctx->table))), (find_action(tokens[1],(ctx->table))), (ctx->table));
     return "The two words are now synonyms!";
 }

--- a/src/cli/src/operations.c
+++ b/src/cli/src/operations.c
@@ -276,8 +276,6 @@ char *name_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
     {
         return "You can't change the meaning of a word that's already defined!";
     }
-    char * newname = malloc(sizeof(char) * strlen(tokens[2]));
-    strcpy(newname, tokens[2]);
     add_entry(tokens[2],(find_operation(tokens[1],(ctx->table))), (find_action(tokens[1],(ctx->table))), (ctx->table));
     return "The two words are now synonyms!";
 }

--- a/src/ui/src/print_functions.c
+++ b/src/ui/src/print_functions.c
@@ -126,9 +126,9 @@ void print_cli(chiventure_ctx_t *ctx, window_t *win)
         do_cmd(c, &quit, ctx);
     }
 
-    // if (cmd_string) {
-    //     free(cmd_string);
-    // }
+    if (cmd_string) {
+        free(cmd_string);
+    }
 
     getyx(win->w, y, x);
 

--- a/src/ui/src/print_functions.c
+++ b/src/ui/src/print_functions.c
@@ -126,7 +126,6 @@ void print_cli(chiventure_ctx_t *ctx, window_t *win)
         do_cmd(c, &quit, ctx);
     }
 
-
     if (cmd_string) {
         free(cmd_string);
     }


### PR DESCRIPTION
Edit: Read to the very end, it gets better!
#369 
Arghh.. I'm tired and I let a leak slip through. While I do free the tables, it doesn't get rid of the rest of the command. As it is, it leaks a lot. This pull should fix it. The memory leak is exactly the size of all of the user input combined up to that point right now. 

This PR makes the only stored info the stuff we need for the new entries in the hashtable.

That minimizes leaking, but it's still there... technically. The memory is actively useful until the context struct is gotten rid of, which is good enough for the presentation. 

Really, this should be a backlog issue. In order to properly dispose of memory with the name command, I should have either rewritten the init_table or whatever it's called to use malloc, or add a linked list of pointers to be freed to the context struct. 

The best way to get rid of the leak entirely, if 0 prejudice is wanted, is this PR, but then deleting the entire name_operation, and any function call that references it. (Not too much to do.)
