### PR TITLE
Fixed issue when q was pressed to quit displaying output

### DIFF
--- a/src/ui/src/print_functions.c
+++ b/src/ui/src/print_functions.c
@@ -184,13 +184,14 @@ void print_to_cli(chiventure_ctx_t *ctx, char *str)
                 /* wait until enter is pressed or q are pressed */
             }
 
+            wmove(cli, y, 2);
+            wclrtoeol(cli);
             if (ch == 'q') {
                 return;
             }
             // sets the cursor to the begining of the line just printed
             // ("Press ENTER to see more, 'q' to continue"), and then clears it
-            wmove(cli, y, 2);
-            wclrtoeol(cli);
+
 
 
             // scrolls the screen up


### PR DESCRIPTION
Fixed issue that when q was pressed the instruction line to press enter or q did not disappear.