### PR TITLE
Fixes memory leaks #374

### DIFF
--- a/src/cli/src/cmd.c
+++ b/src/cli/src/cmd.c
@@ -12,7 +12,7 @@
 void add_entry(char *command_name, operation *associated_operation, action_type_t *action, lookup_t **table)
 {
     lookup_t *t = malloc(sizeof(lookup_t));
-    char *newname = malloc(sizeof(char) * strlen(command_name));
+    char *newname = malloc(sizeof(char) * (strlen(command_name) + 1));
     strcpy(newname, command_name);
     t->name = newname;
     t->operation_type = associated_operation;

--- a/src/cli/src/cmd.c
+++ b/src/cli/src/cmd.c
@@ -12,7 +12,9 @@
 void add_entry(char *command_name, operation *associated_operation, action_type_t *action, lookup_t **table)
 {
     lookup_t *t = malloc(sizeof(lookup_t));
-    t->name = command_name;
+    char *newname = malloc(sizeof(char) * strlen(command_name));
+    strcpy(newname, command_name);
+    t->name = newname;
     t->operation_type = associated_operation;
     t->action = action;
     HASH_ADD_KEYPTR(hh, *table, t->name, strlen(t->name), t);
@@ -132,6 +134,8 @@ int lookup_t_free(lookup_t **t)
     {
         HASH_DEL(*t, current_user);
         free(current_user);
+        free(current_user->name);
+
     }
     return SUCCESS;
 }

--- a/src/cli/src/cmd.c
+++ b/src/cli/src/cmd.c
@@ -71,6 +71,7 @@ void delete_entry(char *command_name, lookup_t **table)
 {
     lookup_t *t = find_entry(command_name, table);
     HASH_DEL(*table, t);
+    free(t->name);
     free(t);
 }
 
@@ -133,8 +134,8 @@ int lookup_t_free(lookup_t **t)
     HASH_ITER(hh, *t, current_user, tmp)
     {
         HASH_DEL(*t, current_user);
-        free(current_user);
         free(current_user->name);
+        free(current_user);
 
     }
     return SUCCESS;

--- a/src/cli/src/operations.c
+++ b/src/cli/src/operations.c
@@ -163,7 +163,7 @@ char *kind1_action_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ct
         {
             HASH_DEL(game->curr_room->items, curr_item);
             add_item_to_player(game->curr_player, curr_item);
-            
+
         }
         return str;
     }

--- a/src/ui/src/print_functions.c
+++ b/src/ui/src/print_functions.c
@@ -165,9 +165,10 @@ void print_cli(chiventure_ctx_t *ctx, window_t *win)
     {
         do_cmd(c, &quit, ctx);
     }
-    if (cmd_string) {
-         free(cmd_string);
-     }
+    if (cmd_string)
+    {
+        free(cmd_string);
+    }
     getyx(win->w, y, x);
 
     // scrolls the screen up if there is no space to print the next line
@@ -214,10 +215,13 @@ void print_to_cli(chiventure_ctx_t *ctx, char *str)
 
     while (tmp != NULL)
     {
-        if(first_run) {
+        if(first_run)
+        {
             mvwprintw(cli, y + 1, 3, tmp);
             first_run = false;
-        } else {
+        }
+        else
+        {
             mvwprintw(cli, y, 3, tmp);
         }
         tmp = strtok(NULL, "\n");

--- a/src/ui/src/print_functions.c
+++ b/src/ui/src/print_functions.c
@@ -165,6 +165,11 @@ void print_cli(chiventure_ctx_t *ctx, window_t *win)
     {
         do_cmd(c, &quit, ctx);
     }
+
+    /* Note: The following statement should be replaced by a logging function
+     * in order to properly implement the HIST command. Should take about
+     * half an hour, tops for someone who's experienced.
+     */
     if (cmd_string)
     {
         free(cmd_string);

--- a/src/ui/src/print_functions.c
+++ b/src/ui/src/print_functions.c
@@ -142,7 +142,7 @@ void print_cli(chiventure_ctx_t *ctx, window_t *win)
         return;
     }
     echo();
-    
+
     char input[80];
     int quit = 1;
     char *cmd_string;
@@ -165,7 +165,9 @@ void print_cli(chiventure_ctx_t *ctx, window_t *win)
     {
         do_cmd(c, &quit, ctx);
     }
-
+    if (cmd_string) {
+         free(cmd_string);
+     }
     getyx(win->w, y, x);
 
     // scrolls the screen up if there is no space to print the next line


### PR DESCRIPTION
See https://github.com/uchicago-cs/chiventure/pull/374
The changes made roughly follow this form:
In the UI segment: previously, each string put in the input buffer for CLI was malloced but not freed. This was a conscious decision made unilaterally by me and mostly unnoticed by others last year, in order to reuse strings in the buffer as internal references.

(This was an awful idea, made late at night in confusion. I fixed it almost immediately after, but the request was denied due to it being less than 24 hours before final presentations.)

In the CLI segment:
The system adding entries for new commands to the lookup table is the only thing that needs to "remember" raw input, with the deletion of the history command. So I made it copy strings and free the new ones later. 

Lastly, I also left some constructive comments in case someone wants to add HIST back in. (If they want to, let me know if they need help!)



 

