### PR TITLE
Conform return values in validate files to macros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
 branches:
   only:
   - master
+  - dev
 
 language: c
 

--- a/include/wdl/validate.h
+++ b/include/wdl/validate.h
@@ -39,9 +39,9 @@ attr_list_t *connections_get_list(obj_t *obj);
  * - obj: a connection object
  *
  * returns:
- * - true if connection types match, else return false
+ * - SUCCESS if connection types match, else return FAILURE
  */
-bool check_connection_attr(obj_t *obj);
+int check_connection_attr(obj_t *obj);
 
 /* print_item
  * prints the attributes associated with the item: id, short_desc, long_desc,
@@ -99,12 +99,12 @@ void print_game(obj_t *obj);
  *  - a function pointer to a type checking function
  *
  * returns:
- *  - true if all objects in the list pass the type checker
- *  - false if else
+ *  - SUCCESS if all objects in the list pass the type checker
+ *  - FAILURE if else
  *
  * note: behaviour is undefined if object and validation function do not match
  */
-bool list_type_check(attr_list_t *ls, bool(*validate)(obj_t*));
+int list_type_check(attr_list_t *ls, int(*validate)(obj_t*));
 
 /* list_print()
  * a function to automate printing objects;
@@ -133,7 +133,7 @@ void list_print(attr_list_t *ls, void(*print)(obj_t*));
  * - obj: object to verify (e.g. ROOMS)
  *
  * Returns:
- * - boolean indicating whether the object has correct attributes
+ * - SUCCESS or FAILURE based on whether the object has correct attributes
  *
  * Notes:
  * What we plan to do is first extract an object, such as the room object,
@@ -141,14 +141,14 @@ void list_print(attr_list_t *ls, void(*print)(obj_t*));
  * We will want to then validate each of the attributes by running type_check
  * with list_type_check
  */
-bool game_type_check(obj_t *obj);
+int game_type_check(obj_t *obj);
 
-bool room_type_check(obj_t *obj);
+int room_type_check(obj_t *obj);
 
-bool item_type_check(obj_t *obj);
+int item_type_check(obj_t *obj);
 
-bool player_type_check(obj_t *obj);
+int player_type_check(obj_t *obj);
 
-bool action_type_check(obj_t *obj);
+int action_type_check(obj_t *obj);
 
 #endif /* INCLUDE_VALIDATE_H */

--- a/src/wdl/src/load_game.c
+++ b/src/wdl/src/load_game.c
@@ -77,8 +77,8 @@ game_t *create_game(obj_t *doc)
         exit(0);
     }
 
-    bool check = game_type_check(game);
-    if (check == false)
+    int check = game_type_check(game);
+    if (check == FAILURE)
     {
         fprintf(stderr, "game object fails type checking\n");
         exit(0);

--- a/src/wdl/src/parse.c
+++ b/src/wdl/src/parse.c
@@ -66,7 +66,7 @@ attr_list_t *extract_objects(obj_t *obj, char *str)
         valid = list_type_check(ls, item_type_check);
     }
 
-    if (valid)
+    if (valid == SUCCESS)
     {
         return ls;
     }
@@ -108,7 +108,7 @@ attr_list_t *get_item_actions(obj_t *item)
     }
 
     valid = list_type_check(ls, action_type_check);
-    if (valid)
+    if (valid == SUCCESS)
     {
         return ls;
     }

--- a/src/wdl/src/validate.c
+++ b/src/wdl/src/validate.c
@@ -10,7 +10,7 @@ int list_type_check(attr_list_t *ls, int(*validate)(obj_t*))
 {
     if (ls == NULL)
     {
-        return FAILURE; // if the function returns FAILURE, it will halt parsing
+        return FAILURE; // if the function returns false, it will halt parsing
     }
 
     int result = SUCCESS;
@@ -60,7 +60,7 @@ void list_print(attr_list_t *ls, void (*print)(obj_t*))
  */
 attr_list_t *conditions_get_list(obj_t *obj)
 {
-    obj_t *conditions = obj_get_attr(obj, "conditions", FAILURE);
+    obj_t *conditions = obj_get_attr(obj, "conditions", false);
 
     if (conditions == NULL)
     {
@@ -80,7 +80,7 @@ attr_list_t *conditions_get_list(obj_t *obj)
  * - obj: a condition object
  *
  * returns:
- * - SUCCESS if condition types match, else return FAILURE
+ * - SUCCESS if condition types match, else return false
  */
 int check_condition_attr(obj_t *obj)
 {
@@ -89,7 +89,7 @@ int check_condition_attr(obj_t *obj)
     int state = (obj_get_type(obj, "state") == TYPE_STR);
     int value = (obj_get_type(obj, "value") == TYPE_STR);
 
-    return (id && state && value);
+    return !(id && state && value);
 }
 
 /* condition_type_check()
@@ -100,7 +100,7 @@ int check_condition_attr(obj_t *obj)
  * - obj: a connection object
  *
  * returns:
- * - SUCCESS if attributes of all conditions match, else return FAILURE
+ * - SUCCESS if attributes of all conditions match, else return false
  */
 int condition_type_check(obj_t *obj)
 {
@@ -115,7 +115,7 @@ int condition_type_check(obj_t *obj)
 /* see validate.h */
 attr_list_t *connections_get_list(obj_t *obj)
 {
-    obj_t *connections = obj_get_attr(obj, "connections", FAILURE);
+    obj_t *connections = obj_get_attr(obj, "connections", false);
 
     if (connections == NULL)
     {
@@ -134,7 +134,7 @@ int check_connection_attr(obj_t *obj)
     int id = (obj_get_type(obj, "to") == TYPE_STR);
     int direction = (obj_get_type(obj, "direction") == TYPE_STR);
 
-    return (id && direction);
+    return !(id && direction);
 }
 
 /* connection_type_check()
@@ -145,7 +145,7 @@ int check_connection_attr(obj_t *obj)
  * - obj: a room object
  *
  * returns:
- * - SUCCESS if attributes of all connections match, else return FAILURE
+ * - SUCCESS if attributes of all connections match, else return false
  */
 int connection_type_check(obj_t *obj)
 {
@@ -168,12 +168,12 @@ int room_type_check(obj_t *obj)
     // verify each attribute
     int connections_ver = connection_type_check(obj);
 
-    if (id_ver == FAILURE)
+    if (id_ver == false)
     {
         fprintf(stderr, "id verification failed\n");
     }
 
-    return (id_ver && short_ver && long_ver && connections_ver);
+    return !(id_ver && short_ver && long_ver && connections_ver);
 }
 
 // The following functions regard item type checking
@@ -187,7 +187,7 @@ int item_type_check(obj_t *obj)
     int long_ver = (obj_get_type(obj, "long_desc") == TYPE_STR);
     int in = (obj_get_type(obj, "in") == TYPE_STR);
 
-    return (id_ver && short_ver && long_ver && in);
+    return !(id_ver && short_ver && long_ver && in);
 }
 
 // The following functions regard game type checking
@@ -200,7 +200,7 @@ int game_type_check(obj_t *obj)
     int intro_ver = (obj_get_type(obj, "intro") == TYPE_STR);
     int end_ver = (obj_get_type(obj, "end.0.in_room") == TYPE_STR);
 
-    return (start_ver && intro_ver);
+    return !(start_ver && intro_ver);
 }
 
 
@@ -256,7 +256,7 @@ int action_type_check(obj_t *obj)
     int action_type = (obj_get_type(obj, "action") == TYPE_STR);
     int action_valid = action_validate(obj_get_str(obj, "action"));
 
-    return (action_type && action_valid);
+    return !(action_type && action_valid);
 }
 
 // The following are print functions to print out specific fields within a
@@ -377,9 +377,9 @@ void print_game(obj_t *obj)
 void print_document(obj_t *obj)
 {
     // Extract individual objects
-    obj_t *room_obj = obj_get_attr(obj, "ROOMS", FAILURE);
-    obj_t *item_obj = obj_get_attr(obj, "ITEMS", FAILURE);
-    obj_t *game_obj = obj_get_attr(obj, "GAME", FAILURE);
+    obj_t *room_obj = obj_get_attr(obj, "ROOMS", false);
+    obj_t *item_obj = obj_get_attr(obj, "ITEMS", false);
+    obj_t *game_obj = obj_get_attr(obj, "GAME", false);
 
     // Extract list of rooms and items
     attr_list_t *rooms_ls = obj_list_attr(room_obj);

--- a/src/wdl/src/validate.c
+++ b/src/wdl/src/validate.c
@@ -10,7 +10,7 @@ int list_type_check(attr_list_t *ls, int(*validate)(obj_t*))
 {
     if (ls == NULL)
     {
-        return FAILURE; // if the function returns false, it will halt parsing
+        return FAILURE; // if the function returns FAILURE, it will halt parsing
     }
 
     int result = SUCCESS;
@@ -80,7 +80,7 @@ attr_list_t *conditions_get_list(obj_t *obj)
  * - obj: a condition object
  *
  * returns:
- * - SUCCESS if condition types match, else return false
+ * - SUCCESS if condition types match, else return FAILURE
  */
 int check_condition_attr(obj_t *obj)
 {
@@ -100,7 +100,7 @@ int check_condition_attr(obj_t *obj)
  * - obj: a connection object
  *
  * returns:
- * - SUCCESS if attributes of all conditions match, else return false
+ * - SUCCESS if attributes of all conditions match, else return FAILURE
  */
 int condition_type_check(obj_t *obj)
 {
@@ -145,7 +145,7 @@ int check_connection_attr(obj_t *obj)
  * - obj: a room object
  *
  * returns:
- * - SUCCESS if attributes of all connections match, else return false
+ * - SUCCESS if attributes of all connections match, else return FAILURE
  */
 int connection_type_check(obj_t *obj)
 {

--- a/src/wdl/src/validate.c
+++ b/src/wdl/src/validate.c
@@ -6,14 +6,14 @@
 // The following functions assist with iterating through lists of objects
 
 /* see validate.h */
-bool list_type_check(attr_list_t *ls, bool(*validate)(obj_t*))
+int list_type_check(attr_list_t *ls, int(*validate)(obj_t*))
 {
     if (ls == NULL)
     {
         return false; // if the function returns false, it will halt parsing
     }
 
-    bool result = true;
+    int result = true;
     attr_list_t *curr = ls;
 
     while(curr != NULL)
@@ -82,12 +82,12 @@ attr_list_t *conditions_get_list(obj_t *obj)
  * returns:
  * - true if condition types match, else return false
  */
-bool check_condition_attr(obj_t *obj)
+int check_condition_attr(obj_t *obj)
 {
     // verify types of fields
-    bool id = (obj_get_type(obj, "id") == TYPE_STR);
-    bool state = (obj_get_type(obj, "state") == TYPE_STR);
-    bool value = (obj_get_type(obj, "value") == TYPE_STR);
+    int id = (obj_get_type(obj, "id") == TYPE_STR);
+    int state = (obj_get_type(obj, "state") == TYPE_STR);
+    int value = (obj_get_type(obj, "value") == TYPE_STR);
 
     return (id && state && value);
 }
@@ -102,12 +102,12 @@ bool check_condition_attr(obj_t *obj)
  * returns:
  * - true if attributes of all conditions match, else return false
  */
-bool condition_type_check(obj_t *obj)
+int condition_type_check(obj_t *obj)
 {
     attr_list_t *ls = conditions_get_list(obj);
 
     // call connection_type_check on each connection
-    bool check = list_type_check(ls, check_condition_attr);
+    int check = list_type_check(ls, check_condition_attr);
 
     return check;
 }
@@ -128,11 +128,11 @@ attr_list_t *connections_get_list(obj_t *obj)
 }
 
 /* See validate.h */
-bool check_connection_attr(obj_t *obj)
+int check_connection_attr(obj_t *obj)
 {
     // verify types of fields
-    bool id = (obj_get_type(obj, "to") == TYPE_STR);
-    bool direction = (obj_get_type(obj, "direction") == TYPE_STR);
+    int id = (obj_get_type(obj, "to") == TYPE_STR);
+    int direction = (obj_get_type(obj, "direction") == TYPE_STR);
 
     return (id && direction);
 }
@@ -147,26 +147,26 @@ bool check_connection_attr(obj_t *obj)
  * returns:
  * - true if attributes of all connections match, else return false
  */
-bool connection_type_check(obj_t *obj)
+int connection_type_check(obj_t *obj)
 {
     attr_list_t *ls = connections_get_list(obj);
 
     // call connection_type_check on each connection
-    bool check = list_type_check(ls, check_connection_attr);
+    int check = list_type_check(ls, check_connection_attr);
 
     return check;
 }
 
 /* See validate.h */
-bool room_type_check(obj_t *obj)
+int room_type_check(obj_t *obj)
 {
     // fields to verify
-    bool id_ver = (obj_get_type(obj, "id") == TYPE_STR);
-    bool short_ver = (obj_get_type(obj, "short_desc") == TYPE_STR);
-    bool long_ver = (obj_get_type(obj, "long_desc") == TYPE_STR);
+    int id_ver = (obj_get_type(obj, "id") == TYPE_STR);
+    int short_ver = (obj_get_type(obj, "short_desc") == TYPE_STR);
+    int long_ver = (obj_get_type(obj, "long_desc") == TYPE_STR);
 
     // verify each attribute
-    bool connections_ver = connection_type_check(obj);
+    int connections_ver = connection_type_check(obj);
 
     if (id_ver == false)
     {
@@ -179,13 +179,13 @@ bool room_type_check(obj_t *obj)
 // The following functions regard item type checking
 
 /* See validate.h */
-bool item_type_check(obj_t *obj)
+int item_type_check(obj_t *obj)
 {
     // fields to verify
-    bool id_ver = (obj_get_type(obj, "id") == TYPE_STR);
-    bool short_ver = (obj_get_type(obj, "short_desc") == TYPE_STR);
-    bool long_ver = (obj_get_type(obj, "long_desc") == TYPE_STR);
-    bool in = (obj_get_type(obj, "in") == TYPE_STR);
+    int id_ver = (obj_get_type(obj, "id") == TYPE_STR);
+    int short_ver = (obj_get_type(obj, "short_desc") == TYPE_STR);
+    int long_ver = (obj_get_type(obj, "long_desc") == TYPE_STR);
+    int in = (obj_get_type(obj, "in") == TYPE_STR);
 
     return (id_ver && short_ver && long_ver && in);
 }
@@ -193,12 +193,12 @@ bool item_type_check(obj_t *obj)
 // The following functions regard game type checking
 
 /* See validate.h */
-bool game_type_check(obj_t *obj)
+int game_type_check(obj_t *obj)
 {
     // fields to verify
-    bool start_ver = (obj_get_type(obj, "start") == TYPE_STR);
-    bool intro_ver = (obj_get_type(obj, "intro") == TYPE_STR);
-    bool end_ver = (obj_get_type(obj, "end.0.in_room") == TYPE_STR);
+    int start_ver = (obj_get_type(obj, "start") == TYPE_STR);
+    int intro_ver = (obj_get_type(obj, "intro") == TYPE_STR);
+    int end_ver = (obj_get_type(obj, "end.0.in_room") == TYPE_STR);
 
     return (start_ver && intro_ver);
 }
@@ -218,7 +218,7 @@ bool game_type_check(obj_t *obj)
  *  - true if the action is valid
  *  - false if else
  */
-bool action_validate(char *str)
+int action_validate(char *str)
 {
     // getting a list of valid actions;
     // note that in the future we may wish to use a hasth table
@@ -250,11 +250,11 @@ void print_list(list_action_type_t *ls)
 
 /* see validate.h */
 /* INPUTS AN ITEM OBJ */
-bool action_type_check(obj_t *obj)
+int action_type_check(obj_t *obj)
 {
     // fields to verify
-    bool action_type = (obj_get_type(obj, "action") == TYPE_STR);
-    bool action_valid = action_validate(obj_get_str(obj, "action"));
+    int action_type = (obj_get_type(obj, "action") == TYPE_STR);
+    int action_valid = action_validate(obj_get_str(obj, "action"));
 
     return (action_type && action_valid);
 }

--- a/src/wdl/src/validate.c
+++ b/src/wdl/src/validate.c
@@ -10,10 +10,10 @@ int list_type_check(attr_list_t *ls, int(*validate)(obj_t*))
 {
     if (ls == NULL)
     {
-        return false; // if the function returns false, it will halt parsing
+        return FAILURE; // if the function returns FAILURE, it will halt parsing
     }
 
-    int result = true;
+    int result = SUCCESS;
     attr_list_t *curr = ls;
 
     while(curr != NULL)
@@ -60,7 +60,7 @@ void list_print(attr_list_t *ls, void (*print)(obj_t*))
  */
 attr_list_t *conditions_get_list(obj_t *obj)
 {
-    obj_t *conditions = obj_get_attr(obj, "conditions", false);
+    obj_t *conditions = obj_get_attr(obj, "conditions", FAILURE);
 
     if (conditions == NULL)
     {
@@ -80,7 +80,7 @@ attr_list_t *conditions_get_list(obj_t *obj)
  * - obj: a condition object
  *
  * returns:
- * - true if condition types match, else return false
+ * - SUCCESS if condition types match, else return FAILURE
  */
 int check_condition_attr(obj_t *obj)
 {
@@ -100,7 +100,7 @@ int check_condition_attr(obj_t *obj)
  * - obj: a connection object
  *
  * returns:
- * - true if attributes of all conditions match, else return false
+ * - SUCCESS if attributes of all conditions match, else return FAILURE
  */
 int condition_type_check(obj_t *obj)
 {
@@ -115,7 +115,7 @@ int condition_type_check(obj_t *obj)
 /* see validate.h */
 attr_list_t *connections_get_list(obj_t *obj)
 {
-    obj_t *connections = obj_get_attr(obj, "connections", false);
+    obj_t *connections = obj_get_attr(obj, "connections", FAILURE);
 
     if (connections == NULL)
     {
@@ -145,7 +145,7 @@ int check_connection_attr(obj_t *obj)
  * - obj: a room object
  *
  * returns:
- * - true if attributes of all connections match, else return false
+ * - SUCCESS if attributes of all connections match, else return FAILURE
  */
 int connection_type_check(obj_t *obj)
 {
@@ -168,7 +168,7 @@ int room_type_check(obj_t *obj)
     // verify each attribute
     int connections_ver = connection_type_check(obj);
 
-    if (id_ver == false)
+    if (id_ver == FAILURE)
     {
         fprintf(stderr, "id verification failed\n");
     }
@@ -215,8 +215,8 @@ int game_type_check(obj_t *obj)
  *  - str: the action to check
  *
  * returns
- *  - true if the action is valid
- *  - false if else
+ *  - SUCCESS if the action is valid
+ *  - FAILURE if else
  */
 int action_validate(char *str)
 {
@@ -229,12 +229,12 @@ int action_validate(char *str)
     {
         if (strcmp(curr->act->c_name, str) == 0)
         {
-            return true;
+            return SUCCESS;
         }
         curr = curr->next;
     }
 
-    return false;
+    return FAILURE;
 }
 
 void print_list(list_action_type_t *ls)
@@ -377,9 +377,9 @@ void print_game(obj_t *obj)
 void print_document(obj_t *obj)
 {
     // Extract individual objects
-    obj_t *room_obj = obj_get_attr(obj, "ROOMS", false);
-    obj_t *item_obj = obj_get_attr(obj, "ITEMS", false);
-    obj_t *game_obj = obj_get_attr(obj, "GAME", false);
+    obj_t *room_obj = obj_get_attr(obj, "ROOMS", FAILURE);
+    obj_t *item_obj = obj_get_attr(obj, "ITEMS", FAILURE);
+    obj_t *game_obj = obj_get_attr(obj, "GAME", FAILURE);
 
     // Extract list of rooms and items
     attr_list_t *rooms_ls = obj_list_attr(room_obj);

--- a/tests/wdl/test_validation.c
+++ b/tests/wdl/test_validation.c
@@ -27,8 +27,8 @@ Test(validate, game_type_check)
     obj_t *doc = __get_doc_obj();
     obj_t *game = obj_get_attr(doc, "GAME.0", false);
 
-    bool rc = game_type_check(game);
-    cr_assert_eq(rc, true, "game verification failed");
+    int rc = game_type_check(game);
+    cr_assert_eq(rc, SUCCESS, "game verification failed");
 }
 
 /* tests whether the room fields are valid */
@@ -38,8 +38,8 @@ Test(validate, room_type_check)
     obj_t *doc = __get_doc_obj();
     attr_list_t *rooms = obj_list_attr(obj_get_attr(doc, "ROOMS", false));
 
-    bool rc = list_type_check(rooms, room_type_check);
-    cr_assert_eq(rc, true, "rooms verification failed");
+    int rc = list_type_check(rooms, room_type_check);
+    cr_assert_eq(rc, SUCCESS, "rooms verification failed");
 }
 
 /* tests whether the item fields are valid */
@@ -49,6 +49,6 @@ Test(validate, item_type_check)
     obj_t *doc = __get_doc_obj();
     attr_list_t *items = obj_list_attr(obj_get_attr(doc, "ITEMS", false));
 
-    bool rc = list_type_check(items, item_type_check);
-    cr_assert_eq(rc, true, "items verification failed");
+    int rc = list_type_check(items, item_type_check);
+    cr_assert_eq(rc, SUCCESS, "items verification failed");
 }


### PR DESCRIPTION
Addressing [Issue#314](https://github.com/uchicago-cs/chiventure/issues/314), the return values in validate.c and validate.h were converted from bool type to the macros SUCCESS and FAILURE.