### PR TITLE
Action management/synonyms

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -233,6 +233,25 @@ K1 - Take `<ITEM>`
 ### Default:
 "I can't take the `<ITEM>`"
 
+K1 - Pick up `<ITEM>`
+--------------
+### Conditions:
+- Player must have inventory space for Item
+
+
+### Effects:
+- Take Item out of room (changes room description and state)
+- Put Item in player inventory
+- Decrease player inventory space
+
+### WDL:
+```
+        - pick_up:
+```
+
+### Default:
+"I can't pick up the `<ITEM>`"
+
 K1 - Drop `<ITEM>`
 ----------
 ### Conditions:

--- a/include/action_management/action_structs.h
+++ b/include/action_management/action_structs.h
@@ -22,7 +22,6 @@ enum actions {
     PICKUP,
     DROP,
     CONSUME,
-    USE,
     DRINK,
     EAT,
 

--- a/include/action_management/action_structs.h
+++ b/include/action_management/action_structs.h
@@ -24,7 +24,7 @@ enum actions {
 
     // KIND 2 ACTIONS - ACTION <path>
     GO,
-    WALK
+    WALK,
 
     /* KIND 3 ACTIONS - ACTION <item_item> */
     USE,

--- a/include/action_management/action_structs.h
+++ b/include/action_management/action_structs.h
@@ -19,7 +19,7 @@ enum actions {
     TURNON,
     TURNOFF,
     TAKE,
-    PICK UP,
+    PICKUP,
     DROP,
     CONSUME,
     USE,

--- a/include/action_management/action_structs.h
+++ b/include/action_management/action_structs.h
@@ -18,9 +18,13 @@ enum actions {
     PULL,
     TURNON,
     TURNOFF,
-    TAKE, // synonyms: "pick up"
+    TAKE,
+    PICK UP,
     DROP,
-    CONSUME, // synonyms: "use" "drink" "eat"
+    CONSUME,
+    USE,
+    DRINK,
+    EAT,
 
     // KIND 2 ACTIONS - ACTION <path>
     GO,

--- a/include/action_management/action_structs.h
+++ b/include/action_management/action_structs.h
@@ -23,7 +23,8 @@ enum actions {
     CONSUME, // synonyms: "use" "drink" "eat"
 
     // KIND 2 ACTIONS - ACTION <path>
-    GO, // synonyms: "walk"
+    GO,
+    WALK
 
     /* KIND 3 ACTIONS - ACTION <item_item> */
     USE,

--- a/src/action_management/src/actionmanagement.c
+++ b/src/action_management/src/actionmanagement.c
@@ -149,6 +149,10 @@ int do_path_action(chiventure_ctx_t *c, action_type_t *a, path_t *p, char **ret_
     // validate existence of path and destination
     if ((path_found == NULL) || (room_dest == NULL))
     {
+	printf("path_found: %p\n", path_found);
+	printf("room_dest: %p\n", room_dest);
+	printf("room_curr: %p\n", room_curr);
+	printf("direction: %p\n", direction);
         sprintf(string, "The path or room provided was invalid.");
         *ret_string = string;
         return NOT_ALLOWED_PATH;

--- a/src/action_management/src/actionmanagement.c
+++ b/src/action_management/src/actionmanagement.c
@@ -149,10 +149,6 @@ int do_path_action(chiventure_ctx_t *c, action_type_t *a, path_t *p, char **ret_
     // validate existence of path and destination
     if ((path_found == NULL) || (room_dest == NULL))
     {
-	printf("path_found: %p\n", path_found);
-	printf("room_dest: %p\n", room_dest);
-	printf("room_curr: %p\n", room_curr);
-	printf("direction: %p\n", direction);
         sprintf(string, "The path or room provided was invalid.");
         *ret_string = string;
         return NOT_ALLOWED_PATH;

--- a/src/action_management/src/get_actions.c
+++ b/src/action_management/src/get_actions.c
@@ -19,7 +19,7 @@ static action_type_t valid_actions[] =
     {"CONSUME", ITEM},
     // KIND 2
     {"GO", PATH},
-    {"WALK", PATH}
+    {"WALK", PATH},
     // KIND 3
     {"USE", ITEM_ITEM},
     {"PUT", ITEM_ITEM}

--- a/src/action_management/src/get_actions.c
+++ b/src/action_management/src/get_actions.c
@@ -15,8 +15,12 @@ static action_type_t valid_actions[] =
     {"TURNON", ITEM},
     {"TURNOFF", ITEM},
     {"TAKE", ITEM},
+    {"PICK UP", ITEM},
     {"DROP", ITEM},
     {"CONSUME", ITEM},
+    {"USE", ITEM},
+    {"DRINK", ITEM},
+    {"EAT", ITEM},
     // KIND 2
     {"GO", PATH},
     {"WALK", PATH},

--- a/src/action_management/src/get_actions.c
+++ b/src/action_management/src/get_actions.c
@@ -19,6 +19,7 @@ static action_type_t valid_actions[] =
     {"CONSUME", ITEM},
     // KIND 2
     {"GO", PATH},
+    {"WALK", PATH}
     // KIND 3
     {"USE", ITEM_ITEM},
     {"PUT", ITEM_ITEM}

--- a/tests/action_management/test_get_actions.c
+++ b/tests/action_management/test_get_actions.c
@@ -47,7 +47,7 @@ Test(get_actions, search_success)
     go = search_supported_actions("GO");
     walk = search_supported_actions("WALK");
     use = search_supported_actions("USE");
-    pick_up = search_supported_actions("PICK UP");
+    pick_up = search_supported_actions("PICKUP");
     drink = search_supported_actions("DRINK");
     eat = search_supported_actions("EAT");
 

--- a/tests/action_management/test_get_actions.c
+++ b/tests/action_management/test_get_actions.c
@@ -5,7 +5,7 @@
 #include "action_management/actionmanagement.h"
 
 
-#define NUM_ACTIONS (13)
+#define NUM_ACTIONS (17)
 
 
 Test(get_actions, count)
@@ -41,12 +41,15 @@ action_type_t *search_supported_actions(char *query)
 /* Checks to see if the action list called can be iterated over using string */
 Test(get_actions, search_success)
 {
-    action_type_t *open, *consume, *go, *walk, *use;
+    action_type_t *open, *consume, *go, *walk, *use, *pick_up, *drink, *eat;
     open = search_supported_actions("OPEN");
     consume = search_supported_actions("CONSUME");
     go = search_supported_actions("GO");
     walk = search_supported_actions("WALK");
     use = search_supported_actions("USE");
+    pick_up = search_supported_actions("PICK UP");
+    drink = search_supported_actions("DRINK");
+    eat = search_supported_actions("EAT");
 
     cr_assert_neq(open, NULL,
                   "search_supported_actions returned a null for query \"open\".\n");
@@ -58,6 +61,12 @@ Test(get_actions, search_success)
                   "search_supported_actions returned a null for query \"walk\".\n");
     cr_assert_neq(use, NULL,
                   "search_supported_actions returned a null for query \"use on\".\n");
+    cr_assert_neq(pick_up, NULL,
+                  "search_supported_actions returned a null for query \"pick up\".\n");
+    cr_assert_neq(drink, NULL,
+                  "search_supported_actions returned a null for query \"drink\".\n");
+    cr_assert_neq(eat, NULL,
+                  "search_supported_actions returned a null for query \"eat\.\n");
 
     cr_assert_eq(open->kind, ITEM,
                  "Expected the action kind %d, but got action kind %d.\n",
@@ -74,6 +83,18 @@ Test(get_actions, search_success)
     cr_assert_eq(use->kind, ITEM_ITEM,
                  "Expected the action kind %d, but got action kind %d.\n",
                  ITEM_ITEM, use->kind);
+    cr_assert_eq(use->kind, ITEM,
+                 "Expected the action kind %d, but got action kind %d.\n",
+                 ITEM, use->kind);
+    cr_assert_eq(pick_up->kind, ITEM,
+                 "Expected the action kind %d, but got action kind %d.\n",
+                 ITEM, pick_up->kind);
+    cr_assert_eq(drink->kind, ITEM,
+                 "Expected the action kind %d, but got action kind %d.\n",
+                 ITEM, drink->kind);
+    cr_assert_eq(eat->kind, ITEM,
+                 "Expected the action kind %d, but got action kind %d.\n",
+                 ITEM, eat->kind);
 }
 
 

--- a/tests/action_management/test_get_actions.c
+++ b/tests/action_management/test_get_actions.c
@@ -55,7 +55,7 @@ Test(get_actions, search_success)
     cr_assert_neq(go, NULL,
                   "search_supported_actions returned a null for query \"go\".\n");
     cr_assert_neq(walk, NULL,
-                  "search_supported_actions returned a null for query \"use on\".\n");
+                  "search_supported_actions returned a null for query \"walk\".\n");
     cr_assert_neq(use, NULL,
                   "search_supported_actions returned a null for query \"use on\".\n");
 

--- a/tests/action_management/test_get_actions.c
+++ b/tests/action_management/test_get_actions.c
@@ -5,7 +5,7 @@
 #include "action_management/actionmanagement.h"
 
 
-#define NUM_ACTIONS (12)
+#define NUM_ACTIONS (13)
 
 
 Test(get_actions, count)
@@ -41,10 +41,11 @@ action_type_t *search_supported_actions(char *query)
 /* Checks to see if the action list called can be iterated over using string */
 Test(get_actions, search_success)
 {
-    action_type_t *open, *consume, *go, *use;
+    action_type_t *open, *consume, *go, *walk, *use;
     open = search_supported_actions("OPEN");
     consume = search_supported_actions("CONSUME");
     go = search_supported_actions("GO");
+    walk = search_supported_actions("WALK");
     use = search_supported_actions("USE");
 
     cr_assert_neq(open, NULL,
@@ -53,6 +54,8 @@ Test(get_actions, search_success)
                   "search_supported_actions returned a null for query \"consume\".\n");
     cr_assert_neq(go, NULL,
                   "search_supported_actions returned a null for query \"go\".\n");
+    cr_assert_neq(walk, NULL,
+                  "search_supported_actions returned a null for query \"use on\".\n");
     cr_assert_neq(use, NULL,
                   "search_supported_actions returned a null for query \"use on\".\n");
 
@@ -65,6 +68,9 @@ Test(get_actions, search_success)
     cr_assert_eq(go->kind, PATH,
                  "Expected the action kind %d, but got action kind %d.\n",
                  PATH, go->kind);
+    cr_assert_eq(walk->kind, PATH,
+                 "Expected the action kind %d, but got action kind %d.\n",
+                 PATH, walk->kind);
     cr_assert_eq(use->kind, ITEM_ITEM,
                  "Expected the action kind %d, but got action kind %d.\n",
                  ITEM_ITEM, use->kind);

--- a/tests/action_management/test_path_actions.c
+++ b/tests/action_management/test_path_actions.c
@@ -63,9 +63,12 @@ Test(path_actions, validate_path)
 
     /* SUCCESS TEST */
     check_do_path(ctx_test, action_go, path_north, room_north, SUCCESS);
-    check_do_path(ctx_test, action_walk, path_north, room_north, SUCCESS);
     // player should be in room_north
     check_do_path(ctx_test, action_go, path_origin, room_origin, SUCCESS);
+    // player should be in room_origin
+
+    check_do_path(ctx_test, action_walk, path_north, room_north, SUCCESS);
+    // player should be in room_north
     check_do_path(ctx_test, action_walk, path_origin, room_origin, SUCCESS);
     // player should be in room_origin
 

--- a/tests/action_management/test_path_actions.c
+++ b/tests/action_management/test_path_actions.c
@@ -38,7 +38,7 @@ Test(path_actions, validate_path)
     player_t *player_test;
     room_t *room_north, *room_origin;
     path_t *path_north, *path_origin;
-    action_type_t *action_go, *action_invalid;
+    action_type_t *action_go, *action_walk, *action_invalid;
 
     /* CREATE VARIABLE CONTENTS */
     ctx_test = chiventure_ctx_new(NULL);
@@ -47,6 +47,7 @@ Test(path_actions, validate_path)
     room_origin = room_new("room_o", "origin room", "This is the room the player starts in.");
     room_north = room_new("room_n", "room north of origin", "This is the room north of the spawn.");
     action_go = action_type_new("GO", PATH);
+    action_walk = action_type_new("WALK", PATH);
     action_invalid = action_type_new("OPEN", ITEM);
 
     /* FILL VARIABLE CONTENTS */
@@ -63,17 +64,21 @@ Test(path_actions, validate_path)
 
     /* SUCCESS TEST */
     check_do_path(ctx_test, action_go, path_north, room_north, SUCCESS);
+    check_do_path(ctx_test, action_walk, path_north, room_north, SUCCESS);
     // player should be in room_north
     check_do_path(ctx_test, action_go, path_origin, room_origin, SUCCESS);
+    check_do_path(ctx_test, action_walk, path_origin, room_origin, SUCCESS);
     // player should be in room_origin
 
     /* FAIL TESTS */
     check_do_path(ctx_test, action_invalid, path_north, room_origin, WRONG_KIND);
     check_do_path(ctx_test, action_go, path_origin, room_origin, NOT_ALLOWED_PATH);
+    check_do_path(ctx_test, action_walk, path_origin, room_origin, NOT_ALLOWED_PATH);
 
     /* FREE VARIABLES */
     chiventure_ctx_free(ctx_test);
     game_free(game_test);
     action_type_free(action_go);
+    action_type_free(action_walk);
     action_type_free(action_invalid);
 }

--- a/tests/action_management/test_path_actions.c
+++ b/tests/action_management/test_path_actions.c
@@ -19,9 +19,6 @@ void check_do_path(chiventure_ctx_t *c, action_type_t *a, path_t *p, room_t *roo
 
     rc = do_path_action(c, a, p, &ret_string);
     room_output = c->game->curr_room;
-printf("path: %p", p);
-printf("rc: %p", rc);
-printf("room: %p", room_expected);
     cr_expect_eq(room_expected, room_output,
                  "The room expected, %s, did not match the actual room output, %s.",
                  room_expected->room_id, room_output->room_id);

--- a/tests/action_management/test_path_actions.c
+++ b/tests/action_management/test_path_actions.c
@@ -19,7 +19,9 @@ void check_do_path(chiventure_ctx_t *c, action_type_t *a, path_t *p, room_t *roo
 
     rc = do_path_action(c, a, p, &ret_string);
     room_output = c->game->curr_room;
-
+printf("path: %p", p);
+printf("rc: %p", rc);
+printf("room: %p", room_expected);
     cr_expect_eq(room_expected, room_output,
                  "The room expected, %s, did not match the actual room output, %s.",
                  room_expected->room_id, room_output->room_id);


### PR DESCRIPTION
This PR resolves #120, reintroducing support for action synonyms that were previously removed due to complications with the get_supported_actions() function. The following synonyms are now supported:

```
PICKUP, // synonym for "take"
USE, 
DRINK,
EAT,    // synonyms for "consume"
WALK    // synonym for "go"
```
(The last synonym was implemented in #492)

It also updates the documentation with the new actions.