### PR TITLE
Added a full-game test to the CLI

### DIFF
--- a/include/cli/cmd.h
+++ b/include/cli/cmd.h
@@ -217,17 +217,45 @@ cmd *cmd_from_string(char *s, chiventure_ctx_t *ctx);
 cmd *cmd_from_tokens(char **ts, lookup_t **table);
 
 
+#define CLI_CMD_SUCCESS (0)
+#define CLI_CMD_SUCCESS_NOOUTPUT (1)
+#define CLI_CMD_SUCCESS_QUIT (2)
+#define CLI_CMD_CALLBACK_ERROR (3)
+
+/*
+ * Callback function type for the CLI.
+ *
+ * Functions of this type can be passed to do_cmd,
+ * which will call the function if the command is run
+ * successfully.
+ *
+ * Parameters:
+ *  - ctx: pointer to chiventure context struct
+ *  - outstring: The string to be printed as a result of running this command
+ *  - args: Additional arguments
+ *
+ * Returns:
+ *  - CLI_CMD_SUCCESS: Success
+ *  - CLI_CMD_CALLBACK_ERROR: Callback function was unable to print the string
+ */
+typedef int cli_callback(chiventure_ctx_t *ctx, char *outstring, void *args);
+
 /*
  * Executes the given command
  *
  * Parameters:
  * - pointer to a cmd struct
+ * - callback_func: Pointer to a callback function
+ * - callback_args: Additional arguments to callback function
  * - ctx: pointer to chiventure context struct
  *
  * Returns:
- * - nothing -> output handled elsewhere
+ * - CLI_CMD_SUCCESS: Success, and the command produced some output
+ * - CLI_CMD_SUCCESS_NOOUTPUT: Success, but the command did not produce any output
+ * - CLI_CMD_SUCCESS_QUIT: Success, but the command requires that chiventure quit
+ * - CLI_CMD_CALLBACK_ERROR: Callback function reported an error
  */
-void do_cmd(cmd *c,int *quit, chiventure_ctx_t *ctx);
+int do_cmd(cmd *c, cli_callback callback_func, void *callback_args, chiventure_ctx_t *ctx);
 
 
 #endif /* _CLI_INCLUDE_CMD_H */

--- a/include/ui/print_functions.h
+++ b/include/ui/print_functions.h
@@ -62,15 +62,15 @@ void print_map(chiventure_ctx_t *ctx, window_t *win);
 
 
 /* print_to_cli
- * prints the given string the CLI window
+ * prints the given string the CLI window.
  *
  * Parameters:
- *    - ctx : chiventure context struct
- *    - str : message to be printed
+ *    - ctx: chiventure context struct
+ *    - str: message to be printed
  *
- * No value is returned
+ * Returns:
+ *  - Always returns 0
  */
-void print_to_cli(chiventure_ctx_t *ctx, char *str);
-
+int print_to_cli(chiventure_ctx_t *ctx, char *str);
 
 #endif

--- a/src/cli/examples/testshell.c
+++ b/src/cli/examples/testshell.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <readline/readline.h>
+#include <ui/print_functions.h>
 //#include <readline/history.h>
 #include "cli/cmd.h"
 #include "cli/shell.h"
@@ -33,13 +34,13 @@ char *trim_newline(char *s)
 int main()
 {
     chiventure_ctx_t *ctx = chiventure_ctx_new();
-    int quit = 1;
+    bool quit = false;
     char *cmd_string;
     greet(ctx);
     //rl_bind_key('\t', rl_complete); // Configure readline to auto-complete paths when the tab key is hit.
     //using_history();
 
-    while (quit)
+    while (!quit)
     {
         // Display prompt and read input
         char *input = readline("chiventure (enter HELP for help)> ");
@@ -58,7 +59,11 @@ int main()
         }
         else
         {
-            do_cmd(c,&quit, ctx);
+            int rc = do_cmd(c, print_to_cli, ctx);
+            if (rc == CLI_CMD_SUCCESS_QUIT)
+            {
+                quit = true;
+            }
             // Add valid input to readline history.
             // add_history(input);
         }

--- a/src/cli/src/cmd.c
+++ b/src/cli/src/cmd.c
@@ -246,7 +246,7 @@ cmd *cmd_from_string(char *s, chiventure_ctx_t *ctx)
 /* =================================== */
 
 /* See cmd.h */
-void do_cmd(cmd *c,int *quit, chiventure_ctx_t *ctx)
+int do_cmd(cmd *c, cli_callback callback_func, void *callback_args, chiventure_ctx_t *ctx)
 {
     char *outstring;
     /*
@@ -255,16 +255,20 @@ void do_cmd(cmd *c,int *quit, chiventure_ctx_t *ctx)
      */
     if (strcmp(cmd_name_tos(c),"QUIT")==0)
     {
-        *quit=0;
         (*(c->func_of_cmd))(c->tokens, ctx);
+
+        return CLI_CMD_SUCCESS_QUIT;
     }
     else
     {
         outstring = (*(c->func_of_cmd))(c->tokens, ctx);
         if(outstring!=NULL)
         {
-            print_to_cli(ctx, outstring);
+            return callback_func(ctx, outstring, callback_args);
+        }
+        else
+        {
+            return CLI_CMD_SUCCESS_NOOUTPUT;
         }
     }
-    return;
 }

--- a/src/ui/src/print_functions.c
+++ b/src/ui/src/print_functions.c
@@ -128,6 +128,23 @@ void print_info(chiventure_ctx_t *ctx, window_t *win)
     mvwprintw(win->w, 1, 2, "Main Window");
 }
 
+/* Wrapper for print_to_cli that can be used as a
+ * callback function when calling do_cmd.
+ *
+ * This function conforms to the cli_callback type
+ * (see that type for more details) */
+int cli_ui_callback(chiventure_ctx_t *ctx, char *str, void *args)
+{
+    if(print_to_cli(ctx, str) == EXIT_SUCCESS)
+    {
+        return CLI_CMD_SUCCESS;
+    }
+    else
+    {
+        return CLI_CMD_CALLBACK_ERROR;
+    }
+}
+
 /* see print_functions.h */
 void print_cli(chiventure_ctx_t *ctx, window_t *win)
 {
@@ -144,7 +161,6 @@ void print_cli(chiventure_ctx_t *ctx, window_t *win)
     echo();
 
     char input[80];
-    int quit = 1;
     char *cmd_string;
     wgetnstr(win->w, input, 80);
 
@@ -163,7 +179,7 @@ void print_cli(chiventure_ctx_t *ctx, window_t *win)
     }
     else
     {
-        do_cmd(c, &quit, ctx);
+        int rc = do_cmd(c, cli_ui_callback, NULL, ctx);
     }
 
     /* Note: The following statement should be replaced by a logging function
@@ -194,8 +210,10 @@ void print_map(chiventure_ctx_t *ctx, window_t *win)
     return;
 }
 
+
+
 /* see print_functions.h */
-void print_to_cli(chiventure_ctx_t *ctx, char *str)
+int print_to_cli(chiventure_ctx_t *ctx, char *str)
 {
     int x, y, height;
     static bool first_run = true;
@@ -250,7 +268,7 @@ void print_to_cli(chiventure_ctx_t *ctx, char *str)
             wclrtoeol(cli);
             if (ch == 'q')
             {
-                return;
+                return EXIT_SUCCESS;
             }
             // sets the cursor to the begining of the line just printed
             // ("Press ENTER to see more, 'q' to continue"), and then clears it
@@ -268,4 +286,7 @@ void print_to_cli(chiventure_ctx_t *ctx, char *str)
 
     getyx(cli, y, x);
     wmove(cli, y+1, 2);
+
+    return EXIT_SUCCESS;
 }
+

--- a/tests/cli/CMakeLists.txt
+++ b/tests/cli/CMakeLists.txt
@@ -3,6 +3,7 @@ set(TEST_EXE test-cli)
 add_executable(${TEST_EXE}
         test_cmd.c
         test_parser.c
+        test_game.c
         main.c)
 
 target_link_libraries(${TEST_EXE} ${CRITERION_LIBRARY})

--- a/tests/cli/test_game.c
+++ b/tests/cli/test_game.c
@@ -1,0 +1,50 @@
+#include <criterion/criterion.h>
+#include <string.h>
+#include <ui/ui.h>
+#include "game-state/game.h"
+#include "common/ctx.h"
+
+chiventure_ctx_t *create_sample_ctx()
+{
+    chiventure_ctx_t *ctx = chiventure_ctx_new(NULL);
+
+    game_t *game = game_new("Welcome to Chiventure!");
+    room_t *room1 = room_new("room1", "This is room 1", "Verily, this is the first room.");
+    room_t *room2 = room_new("room2", "This is room 2", "Truly, this is the second room.");
+    add_room_to_game(game, room1);
+    add_room_to_game(game, room2);
+    game->curr_room = room1;
+    create_connection(game, "room1", "room2", "north");
+
+    /* Free default game and replace it with ours */
+    game_free(ctx->game);
+    ctx->game = game;
+
+    return ctx;
+}
+
+int test_callback(chiventure_ctx_t *ctx, char *outstr, void* args)
+{
+    char *expected = (char*) args;
+
+    cr_assert_str_eq(outstr, expected);
+
+    return CLI_CMD_SUCCESS;
+}
+
+/* Creates a sample game and runs the LOOK command */
+Test(game, look)
+{
+    int quit;
+    chiventure_ctx_t *ctx = create_sample_ctx();
+
+    char *cmd_str = strdup("LOOK");
+    cmd *cmd = cmd_from_string(cmd_str, ctx);
+    cr_assert_not_null(cmd, "cmd_from_string failed");
+
+    do_cmd(cmd, test_callback, "Verily, this is the first room.", ctx);
+
+    free(cmd_str);
+    game_free(ctx->game);
+    chiventure_ctx_free(ctx);
+}


### PR DESCRIPTION
This PR ultimately adds a full-game test to the CLI (where a game is created in-memory from scratch, so we can test CLI functions on it). However, this required some non-trivial re-factoring, because there was no way to test the CLI functions without starting the UI (which prevents the tests from running, since they get stuck in a UI loop). The specific changes are:

- `do_cmd` has been altered to take a callback function (with callback arguments) as parameters. `print_cli` now calls `do_cmd` with a callback function that calls `print_to_cli`.
- The `quit` output parameter of `do_cmd` has been replaced by a return value.
- There was another call to `do_cmd` from `testshell.c` that has also been updated.

With these changes, the full-game test is able to pass a callback function that simply checks whether the output string from the CLI matches the expected one.

The tests all pass, and I've checked that the CLI still works from the UI (running the sample games)

