### PR TITLE
Added additional game test for CLI

### DIFF
--- a/src/cli/src/cmd.c
+++ b/src/cli/src/cmd.c
@@ -262,13 +262,19 @@ int do_cmd(cmd *c, cli_callback callback_func, void *callback_args, chiventure_c
     else
     {
         outstring = (*(c->func_of_cmd))(c->tokens, ctx);
-        if(outstring!=NULL)
+        if(callback_func)
         {
-            return callback_func(ctx, outstring, callback_args);
+            if (outstring != NULL)
+            {
+                return callback_func(ctx, outstring, callback_args);
+            } else
+            {
+                return CLI_CMD_SUCCESS_NOOUTPUT;
+            }
         }
         else
         {
-            return CLI_CMD_SUCCESS_NOOUTPUT;
+            return CLI_CMD_SUCCESS;
         }
     }
 }

--- a/tests/cli/test_game.c
+++ b/tests/cli/test_game.c
@@ -90,7 +90,7 @@ Test(game, go)
 
     do_cmd(cmd, NULL, NULL, ctx);
 
-    /* Check that the game is in the initial room */
+    /* Check that current room has changed */
     cr_assert_eq(ctx->game->curr_room, room2,
                  "GO NORTH did not change the current room as expected");
 


### PR DESCRIPTION
I've added an additional game test for CLI that checks whether the game state has changed as expected, as opposed to checking whether the CLI prints the expected output. This additional test also checks that action management is correctly integrated with the CLI.

Adding this also involved adding support for null callbacks in `do_cmd`.