### PR TITLE
Battle State Minor Fixes (calloc, combatant_free)

### DIFF
--- a/include/battle/battle_state.h
+++ b/include/battle/battle_state.h
@@ -54,7 +54,7 @@ typedef struct combatant {
 
 /* A battle struct that contains the following:
  * - player: a combatant pointer, storing the player
- * - enemies: a combatant pointer, storing the enemy/enemies
+ * - enemy: a combatant pointer, storing the enemy/enemies
  * - environment: stores battle environment
  * - turn: a turn_t enum storing the current turn
  */

--- a/src/battle/src/battle_state.c
+++ b/src/battle/src/battle_state.c
@@ -35,7 +35,7 @@ int combatant_init(combatant_t *c, char *name, bool is_friendly, stat_t *stats,
 {
     assert(c != NULL);
 
-    c->name = calloc(MAX_NAME_LEN, sizeof(char));
+    c->name = calloc(MAX_NAME_LEN + 1, sizeof(char));
     strncpy(c->name, name, MAX_NAME_LEN);
     c->is_friendly= is_friendly;
     c->stats = stats;
@@ -63,9 +63,9 @@ int combatant_free(combatant_t *c)
     }
 
     item_t *item_elt, *item_tmp;
-    DL_FOREACH_SAFE(c->moves, item_elt, item_tmp)
+    DL_FOREACH_SAFE(c->items, item_elt, item_tmp)
     {
-        DL_DELETE(c->moves, item_elt);
+        DL_DELETE(c->items, item_elt);
         free(item_elt);
     }
 


### PR DESCRIPTION
This pull request fixes two minor errors in battle_state.c. 
1. Changing combatant_free() line 66-68 to iterate over and delete combatant's items instead of moves. 
2. Allocating space for MAX_NAME_LEN + 1 in calloc call in combatant_init(), instead of MAX_NAME_LEN. 