### PR TITLE
Removed certain dependencies in chiventure_ctx_t

### DIFF
--- a/include/common/ctx.h
+++ b/include/common/ctx.h
@@ -28,7 +28,9 @@ typedef struct chiventure_ctx {
  * Allocates and initializes a new chiventure context.
  *
  * Parameters:
- *  - game: The game to be run in this context (can be NULL)
+ *  - game: The game to be run in this context.
+ *          If NULL, an empty game is created that simply
+ *          warns the user they need to load a game.
  *
  * Returns:
  *  - A pointer to the context, or NULL if it cannot be allocated
@@ -41,7 +43,9 @@ chiventure_ctx_t* chiventure_ctx_new(game_t *game);
  *
  * Parameters:
  *  - ctx: A chiventure context. Must already point to allocated memory
- *  - game: The game to be run in this context (can be NULL)
+ *  - game: The game to be run in this context.
+ *          If NULL, an empty game is created that simply
+ *          warns the user they need to load a game.
  *
  * Returns:
  *  - 0 on success, 1 if an error occurs.

--- a/include/common/ctx.h
+++ b/include/common/ctx.h
@@ -6,10 +6,8 @@
 #define CHIVENTURE_CHIVENTURE_H
 
 
-#include <ncurses.h>
 #include "common.h"
 #include "game-state/game.h"
-#include "ui/ui_ctx.h"
 #include "cli/cmd.h"
 
 // Forward declaration
@@ -30,12 +28,12 @@ typedef struct chiventure_ctx {
  * Allocates and initializes a new chiventure context.
  *
  * Parameters:
- *  - filepath: path to yaml file to load game
+ *  - game: The game to be run in this context (can be NULL)
  *
  * Returns:
  *  - A pointer to the context, or NULL if it cannot be allocated
  */
-chiventure_ctx_t* chiventure_ctx_new(char *filepath);
+chiventure_ctx_t* chiventure_ctx_new(game_t *game);
 
 
 /*
@@ -43,12 +41,12 @@ chiventure_ctx_t* chiventure_ctx_new(char *filepath);
  *
  * Parameters:
  *  - ctx: A chiventure context. Must already point to allocated memory
- *  - filepath: filepath to yaml file to load game
+ *  - game: The game to be run in this context (can be NULL)
  *
  * Returns:
  *  - 0 on success, 1 if an error occurs.
  */
-int chiventure_ctx_init(chiventure_ctx_t *ctx, char *filepath);
+int chiventure_ctx_init(chiventure_ctx_t *ctx, game_t *game);
 
 
 /*

--- a/include/ui/print_functions.h
+++ b/include/ui/print_functions.h
@@ -2,6 +2,7 @@
 #define PRINT_FUNCTIONS_H
 
 #include "common/ctx.h"
+#include "ui/ui_ctx.h"
 
 
 typedef struct window window_t;

--- a/src/chiventure.c
+++ b/src/chiventure.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
+#include <wdl/load_game.h>
+#include <ui/ui_ctx.h>
 #include "common/ctx.h"
 #include "ui/ui.h"
 
@@ -41,15 +43,19 @@ int main(int argc, char **argv)
         fprintf(stderr, "Chiventure prefers to run in terminals of at least %d columns and %d rows. Please resize your terminal!\n", MIN_COLS, MIN_ROWS);
         exit(1);
     }
-    
-    if (argc <= 1) {
-        chiventure_ctx_t *ctx = chiventure_ctx_new(NULL);
+
+    game_t *game;
+
+    if (argc == 2)
+    {
+        game = load_wdl(argv[1]);
     }
 
-    chiventure_ctx_t *ctx = chiventure_ctx_new(argv[1]);
+    chiventure_ctx_t *ctx = chiventure_ctx_new(game);
 
     /* Add calls to component-specific initializations here */
 
+    /*** UI ***/
     if (ncols > 100) {
         start_ui(ctx, banner);
     } else {
@@ -57,5 +63,6 @@ int main(int argc, char **argv)
     } 
 
     game_free(ctx->game);
+
     return 0;
 }

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(cli checkpointing)
 target_link_libraries(cli action_management)
 target_link_libraries(cli ui)
 target_link_libraries(cli game-state)
+target_link_libraries(cli wdl)
 target_link_libraries(cli common)
 
 # EXAMPLES

--- a/src/cli/examples/extra-command.c
+++ b/src/cli/examples/extra-command.c
@@ -17,8 +17,6 @@ const char *banner = "THIS IS AN EXAMPLE PROGRAM";
 /* Creates a sample in-memory game */
 chiventure_ctx_t *create_sample_ctx()
 {
-    chiventure_ctx_t *ctx = chiventure_ctx_new(NULL);
-
     game_t *game = game_new("Welcome to Chiventure!");
 
     /* Create two rooms (room1 and room2). room1 is the initial room */
@@ -38,9 +36,8 @@ chiventure_ctx_t *create_sample_ctx()
      * It has no conditions, so it should succeed unconditionally. */
     add_action(rock, "TASTE", "It has a gravel-ey bouquet.", "You can't taste the rock.");
 
-    /* Free default game and replace it with ours */
-    game_free(ctx->game);
-    ctx->game = game;
+    /* Create context */
+    chiventure_ctx_t *ctx = chiventure_ctx_new(game);
 
     return ctx;
 }

--- a/src/common/src/ctx.c
+++ b/src/common/src/ctx.c
@@ -1,13 +1,11 @@
 #include <stdlib.h>
 
 #include "common/ctx.h"
-#include "ui/ui_ctx.h"
 #include "cli/cmd.h"
-#include "wdl/load_game.h"
 
 
 /* See ctx.h */
-chiventure_ctx_t* chiventure_ctx_new(char *filepath)
+chiventure_ctx_t* chiventure_ctx_new(game_t *game)
 {
     chiventure_ctx_t *ctx;
     int rc;
@@ -19,7 +17,7 @@ chiventure_ctx_t* chiventure_ctx_new(char *filepath)
         return NULL;
     }
 
-    rc = chiventure_ctx_init(ctx, filepath);
+    rc = chiventure_ctx_init(ctx, game);
     if (rc != SUCCESS)
     {
         return NULL;
@@ -29,31 +27,25 @@ chiventure_ctx_t* chiventure_ctx_new(char *filepath)
 }
 
 /* See ctx.h */
-int chiventure_ctx_init(chiventure_ctx_t *ctx, char *filepath)
+int chiventure_ctx_init(chiventure_ctx_t *ctx, game_t *game)
 {
     assert(ctx != NULL);
 
-    char *desc = "No game has been loaded! Use the LOAD_WDL command to load a game.";
-    game_t *game;
-
-    if(filepath == NULL)
+    if (game)
     {
-        game = game_new(desc);
+        ctx->game = game;
     }
     else
     {
-        game = load_wdl(filepath);
+        ctx->game = game_new("No game has been loaded! Use the LOAD_WDL command to load a game.");
     }
 
-    ui_ctx_t *ui_ctx = ui_ctx_new(game);
     lookup_t **table = lookup_t_new();
 
     player_t *player1 = player_new("player1", 100);
-    add_player_to_game(game, player1);
-    game->curr_player = player1;
+    add_player_to_game(ctx->game, player1);
+    ctx->game->curr_player = player1;
 
-    ctx->game = game;
-    ctx->ui_ctx = ui_ctx;
     ctx->table = table;
 
     return SUCCESS;
@@ -65,7 +57,6 @@ int chiventure_ctx_free(chiventure_ctx_t *ctx)
     assert(ctx != NULL);
 
     /* Add calls to component-specific freeing functions here */
-    ui_ctx_free(ctx->ui_ctx);
 
     free(ctx);
 

--- a/src/ui/src/coordinate.c
+++ b/src/ui/src/coordinate.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <assert.h>
 
+#include "ui/ui_ctx.h"
 #include "ui/coordinate.h"
 
 

--- a/src/ui/src/map.c
+++ b/src/ui/src/map.c
@@ -2,6 +2,8 @@
 #include <stdlib.h>
 #include <ncurses.h>
 
+#include "ui/ui_ctx.h"
+#include "ui/coordinate.h"
 #include "ui/map.h"
 
 void erase_ch(int y, int x)

--- a/src/ui/src/ui.c
+++ b/src/ui/src/ui.c
@@ -19,10 +19,13 @@
 
 void start_ui(chiventure_ctx_t *ctx, const char *banner)
 {
+    /* Create UI context */
+    ui_ctx_t *ui_ctx = ui_ctx_new(ctx->game);
+    ctx->ui_ctx = ui_ctx;
+
     // prevents program from closing on CTRL+C
     signal(SIGINT, SIG_IGN);
 
-    ui_ctx_t *ui_ctx = ctx->ui_ctx;
     int ch;
 
     // starts curses mode
@@ -167,6 +170,9 @@ void start_ui(chiventure_ctx_t *ctx, const char *banner)
 
     // End curses mode
     endwin();
+
+    /* Free UI context */
+    ui_ctx_free(ctx->ui_ctx);
 }
 
 void stop_ui(chiventure_ctx_t *ctx)

--- a/tests/cli/test_game.c
+++ b/tests/cli/test_game.c
@@ -12,8 +12,6 @@
  */
 chiventure_ctx_t *create_sample_ctx()
 {
-    chiventure_ctx_t *ctx = chiventure_ctx_new(NULL);
-
     game_t *game = game_new("Welcome to Chiventure!");
     room_t *room1 = room_new("room1", "This is room 1", "Verily, this is the first room.");
     room_t *room2 = room_new("room2", "This is room 2", "Truly, this is the second room.");
@@ -22,9 +20,8 @@ chiventure_ctx_t *create_sample_ctx()
     game->curr_room = room1;
     create_connection(game, "room1", "room2", "NORTH");
 
-    /* Free default game and replace it with ours */
-    game_free(ctx->game);
-    ctx->game = game;
+    /* Create context */
+    chiventure_ctx_t *ctx = chiventure_ctx_new(game);
 
     return ctx;
 }

--- a/tests/game-state/test_stats.c
+++ b/tests/game-state/test_stats.c
@@ -75,13 +75,13 @@ Test(stats, display_stat)
 /* Checks that global_effect_init correctly initializes a global effect struct */
 Test (stats, effect_global_init)
 {
-    effects_global_t *effect;
+    effects_global_t effect;
 
-    int rc = global_effect_init(effect, "health");
+    int rc = global_effect_init(&effect, "health");
 
     cr_assert_eq(rc, SUCCESS, "global_effect_init failed");
-    cr_assert_not_null(effect->name, "global_effect_init did not set effect name");
-    cr_assert_str_eq(effect->name, "health", "global_effect_init did not set name");
+    cr_assert_not_null(effect.name, "global_effect_init did not set effect name");
+    cr_assert_str_eq(effect.name, "health", "global_effect_init did not set name");
 }
 
 /* Checks that global_effect_new correctly creates a new global effect struct */
@@ -99,13 +99,13 @@ Test (stats, stat_effect_init)
     effects_global_t *global = global_effect_new("speed");
     cr_assert_not_null(global, "global_effect_new failed");
 
-    stat_effect_t *effect;
+    stat_effect_t effect;
 
-    int rc = stat_effect_init(effect, global);
+    int rc = stat_effect_init(&effect, global);
 
     cr_assert_eq(rc, SUCCESS, "stat_effect_init failed");
-    cr_assert_str_eq(effect->key, global->name, "stat_effect_init did not set key");
-    cr_assert_eq(effect->global, global, "stat_effect_init did not set global pointer");
+    cr_assert_str_eq(effect.key, global->name, "stat_effect_init did not set key");
+    cr_assert_eq(effect.global, global, "stat_effect_init did not set global pointer");
 }
 
 /* Checks that stat_effect_new correctly creates a new player effect */


### PR DESCRIPTION
This pull request refactors out a couple of dependencies in chiventure_ctx_t that have proven to be problematic. Most notably:

- The UI context is no longer initialized in `chiventure_ctx_init` but, rather, inside `start_ui` (we could also move this initialization code to `chiventure.c`, but I'm not sure that's necessary given that the only situation where we need an initialized UI context is if we're going to run the UI). This means that the `ncurses.h` header file is only included in the UI code (where previously it ended up being included indirectly from `ctx.h`, which was causing issues for the graphics team)
- `chiventure_ctx_init` and `chiventure_ctx_new` now take a `game_t` as a parameter instead of a filepath. This provides more flexibility when creating a context object, where a game may be created in memory (instead of being loaded from a file). Previously, we had to pass a NULL `filepath`, and then replace the default game with the in-memory game (see `extra-command.c` for an example of this)

Unrelated to this refactoring, the changes brought to light a small issue in the game-state tests, where unallocated memory was being passed to a function that expected that memory to be allocated (and was not previously segfaulting by chance). 