### PR TITLE
Custom Scripts Custom Type Struct Being implemented for npcs 

### DIFF
--- a/include/npc/npc.h
+++ b/include/npc/npc.h
@@ -5,12 +5,20 @@
 #include "game-state/item.h"
 //TODO-#include "dialogue.h"
 #include "playerclass/class_structs.h"
+#include "custom-scripts/custom_type.h"
 
 /* A non-playable character in game */
+
+/*Object_t Description: object_t is the generic custom scripts struct 
+that can hold a variety of different types including "char *".*/
+
+/*Changes to Room_ID: We are using this struct to modify the npc_id 
+which will enable custom scripts and lua files to be loaded*/
+
 typedef struct npc {
     /* hh is used for hashtable, as provided in uthash.h */
     UT_hash_handle hh;
-    char *npc_id;
+    object_t *npc_id;
     int health;
     // convo_t *dialogue;  placeholder for incoming dialogue module
     item_hash_t *inventory;
@@ -40,7 +48,7 @@ typedef struct npc npc_hash_t;
  * Returns:
  *  SUCCESS on success, FAILURE if an error occurs
  */
-int npc_init(npc_t *npc, char *npc_id, int health, class_t *class);
+int npc_init(npc_t *npc, object_t *npc_id, int health, class_t *class);
 
 
 /*
@@ -56,7 +64,7 @@ int npc_init(npc_t *npc, char *npc_id, int health, class_t *class);
  * Returns:
  *  pointer to allocated npc
  */
- npc_t* npc_new(char *npc_id, int health, class_t *class);
+ npc_t* npc_new(object_t *npc_id, int health, class_t *class);
 
 
 /*

--- a/src/npc/src/npc.c
+++ b/src/npc/src/npc.c
@@ -2,10 +2,11 @@
 #include "game-state/item.h"
 
 /* See npc.h */
-int npc_init(npc_t *npc, char *npc_id, int health, class_t *class) //TODO-convo_t *dialogue)
+int npc_init(npc_t *npc, object_t *npc_id, int health, class_t *class) //TODO-convo_t *dialogue)
 {
     assert(npc != NULL);
-    strncpy(npc->npc_id, npc_id, strlen(npc_id));
+    npc->npc_id = npc_id;
+    //strncpy(npc->npc_id, npc_id, strlen(npc_id));
     npc->health = health;
     //TODO-npc->dialogue = dialogue;
     npc->inventory = NULL;
@@ -15,7 +16,7 @@ int npc_init(npc_t *npc, char *npc_id, int health, class_t *class) //TODO-convo_
 }
 
 /* See npc.h */
-npc_t* npc_new(char *npc_id, int health, class_t *class)
+npc_t* npc_new(object_t *npc_id, int health, class_t *class)
 {
     npc_t *npc;
     npc = malloc(sizeof(npc_t));


### PR DESCRIPTION
This PR implements the custom type module and specifically the object_t struct to be used within the npc struct. This flexible data structure that can hold either a fundamental data type, such as bool, char, int, etc., or a Lua directory which will be responsible for returning the data. IN our case, we applied this struct to modify the room_id variable which was previously a char*.

Changes:

Updates to the npc.c and npc.h files in the npc directory.
Modifications to the npc_id variable inside these two files and the existing npc struct.