### PR TITLE
Hotfix: Uninitialized game was causing segfault

### DIFF
--- a/src/chiventure.c
+++ b/src/chiventure.c
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    game_t *game;
+    game_t *game = NULL;
 
     if (argc == 2)
     {


### PR DESCRIPTION
When calling `chiventure_ctx_new` (or `chiventure_ctx_init`), the `game_t` parameter has to either be NULL or point to a valid game. In `chiventure.c`, the `game` was not being initialized to `NULL`, so the `ctx` functions were treating the (uninitialized) memory it pointed to as a game, leading to a segfault.