### PR TITLE
Update Documentation for Action Synonyms

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -214,6 +214,9 @@ K2 - Go [direction]
 ### Default:
 "I can't find a way to go [direction]"
 
+### Synonyms:
+Walk
+
 K1 - Take `<ITEM>`
 --------------
 ### Conditions:
@@ -232,6 +235,9 @@ K1 - Take `<ITEM>`
 
 ### Default:
 "I can't take the `<ITEM>`"
+
+### Synonyms:
+Pickup
 
 K1 - Pick up `<ITEM>`
 --------------
@@ -287,22 +293,8 @@ K1 - Use `<ITEM>`
 ### Default:
 "I can't figure out how to use the `<ITEM>`"
 
-K5 - Use `<ITEM>` on `<ITEM>`
-------------
-### Conditions:
-- No additional Conditions
-
-
-### Effects:
-- No additional effects
-
-### WDL:
-```
-        - use_on:
-```
-
-### Default:
-"I can't figure out how to use the `<ITEM>` on the `<ITEM>`"
+### Synonyms:
+Consume, Eat, Drink
 
 K1 - Drink `<ITEM>`
 ---------
@@ -336,3 +328,37 @@ K1 - Eat `<ITEM>`
 
 ### Default:
 "I do not want to eat the `<ITEM>`"
+
+K1 - Consume `<ITEM>`
+---------
+### Conditions:
+- Item must be solid
+
+
+### Effects:
+- No additional effects
+
+### WDL:
+```
+        - consume:
+```
+
+### Default:
+"I do not want to consume the `<ITEM>`"
+
+K3 - Use `<ITEM>` on `<ITEM>`
+------------
+### Conditions:
+- No additional Conditions
+
+
+### Effects:
+- No additional effects
+
+### WDL:
+```
+        - use_on:
+```
+
+### Default:
+"I can't figure out how to use the `<ITEM>` on the `<ITEM>`"

--- a/include/action_management/action_structs.h
+++ b/include/action_management/action_structs.h
@@ -19,14 +19,12 @@ enum actions {
     TURNON,
     TURNOFF,
     TAKE,
-    PICKUP,  // This action is legal but not implemented
+    PICKUP,
     DROP,
     CONSUME,
-    /* These actions are legal but not implemented */
     USE,
     DRINK,
     EAT,
-    /* ^ These actions are legal but not implemented ^ */
 
     // KIND 2 ACTIONS - ACTION <path>
     GO,


### PR DESCRIPTION
The following action synonyms were implemented without proper documentation in `docs/actions.md`: 
```
// Synonyms for GO
WALK

// Synonyms for USE
CONSUME, EAT, DRINK
```

This PR updates the documentation to reflect the new synonyms, and fixes other errors in  `actions.md`.  It also changes `action_structs.h` to reflect that all synonyms are now both legal and implemented in chiventure.