### PR TITLE
Hotfix: Do not call load_objects if WDL file has not been specified

### DIFF
--- a/src/chiventure.c
+++ b/src/chiventure.c
@@ -45,15 +45,14 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    wdl_ctx_t *wdl_ctx;
+    wdl_ctx_t *wdl_ctx = NULL;
     game_t *game = NULL;
 
     if (argc == 2)
     {
         wdl_ctx = load_wdl(argv[1]);
+        game = load_objects(wdl_ctx);
     }
-
-    game = load_objects(wdl_ctx);
 
     chiventure_ctx_t *ctx = chiventure_ctx_new(game);
 


### PR DESCRIPTION
`chiventure.c` had been modified to unconditionally call `load_objects`, when this function should only be called when a WDL file has been specified. Otherwise, the empty game should be loaded as usual.