### PR TITLE
Adding type-specific attribute creation functions to streamline Player Class/Attribute integration

### DIFF
--- a/include/game-state/item.h
+++ b/include/game-state/item.h
@@ -233,6 +233,51 @@ int attributes_equal(item_t* item_1, item_t* item_2, char* attribute_name);
 // the following functions allow their users to add attributes to the given
 // item or replace (read: change) attributes associated
 
+/* str_attr_new() creates a new string-specific attribute
+ * Parameters:
+ *  Name of the attribute (char*)
+ *  The value to add to the attribute
+ * Returns:
+ *  Pointer to the new attribute, NULL if memory was unable to be allocated
+ */
+attribute_t* str_attr_new(char* attr_name, char* value);
+
+/* int_attr_new() creates a new integer-specific attribute
+ * Parameters:
+ *  Name of the attribute (char*)
+ *  The value to add to the attribute
+ * Returns:
+ *  Pointer to the new attribute, NULL if memory was unable to be allocated
+ */
+attribute_t* int_attr_new(char* attr_name, int value);
+
+/* double_attr_new() creates a new double-specific attribute
+ * Parameters:
+ *  Name of the attribute (char*)
+ *  The value to add to the attribute
+ * Returns:
+ *  Pointer to the new attribute, NULL if memory was unable to be allocated
+ */
+attribute_t* double_attr_new(char* attr_name, double value);
+
+/* char_attr_new() creates a new char-specific attribute
+ * Parameters:
+ *  Name of the attribute (char*)
+ *  The value to add to the attribute
+ * Returns:
+ *  Pointer to the new attribute, NULL if memory was unable to be allocated
+ */
+attribute_t* char_attr_new(char* attr_name, char value);
+
+/* bool_attr_new() creates a new bool-specific attribute
+ * Parameters:
+ *  Name of the attribute (char*)
+ *  The value to add to the attribute
+ * Returns:
+ *  Pointer to the new attribute, NULL if memory was unable to be allocated
+ */
+attribute_t* bool_attr_new(char* attr_name, bool value);
+
 /* set_str_attr() sets the value of an attribute of an item to the given string
  * Parameters:
  *  a pointer to the item

--- a/src/game-state/src/item.c
+++ b/src/game-state/src/item.c
@@ -213,14 +213,15 @@ attribute_t *get_attribute(item_t *item, char* attr_name)
 attribute_t* str_attr_new(char* attr_name, char* value)
 {
     attribute_t* new_attribute = malloc(sizeof(attribute_t));
-    new_attribute->attribute_tag = STRING;
-    new_attribute->attribute_value.str_val = value;
-    new_attribute->attribute_key = strndup(attr_name, 100);
 
     if (new_attribute == NULL) {
         fprintf(stderr, "Failed to allocate memory for new attribute");
         return NULL;
     }
+
+    new_attribute->attribute_tag = STRING;
+    new_attribute->attribute_value.str_val = value;
+    new_attribute->attribute_key = strndup(attr_name, MAX_ID_LEN);
 
     return new_attribute;
 }
@@ -230,14 +231,15 @@ attribute_t* str_attr_new(char* attr_name, char* value)
 attribute_t* int_attr_new(char* attr_name, int value)
 {
     attribute_t* new_attribute = malloc(sizeof(attribute_t));
-    new_attribute->attribute_tag = INTEGER;
-    new_attribute->attribute_value.int_val = value;
-    new_attribute->attribute_key = strndup(attr_name, 100);
 
     if (new_attribute == NULL) {
         fprintf(stderr, "Failed to allocate memory for new attribute");
         return NULL;
     }
+
+    new_attribute->attribute_tag = INTEGER;
+    new_attribute->attribute_value.int_val = value;
+    new_attribute->attribute_key = strndup(attr_name, MAX_ID_LEN);
 
     return new_attribute;
 }
@@ -247,14 +249,15 @@ attribute_t* int_attr_new(char* attr_name, int value)
 attribute_t* double_attr_new(char* attr_name, double value)
 {
     attribute_t* new_attribute = malloc(sizeof(attribute_t));
-    new_attribute->attribute_tag = DOUBLE;
-    new_attribute->attribute_value.double_val = value;
-    new_attribute->attribute_key = strndup(attr_name, 100);
 
     if (new_attribute == NULL) {
         fprintf(stderr, "Failed to allocate memory for new attribute");
         return NULL;
     }
+
+    new_attribute->attribute_tag = DOUBLE;
+    new_attribute->attribute_value.double_val = value;
+    new_attribute->attribute_key = strndup(attr_name, MAX_ID_LEN);
 
     return new_attribute;
 }
@@ -264,14 +267,15 @@ attribute_t* double_attr_new(char* attr_name, double value)
 attribute_t* char_attr_new(char* attr_name, char value)
 {
     attribute_t* new_attribute = malloc(sizeof(attribute_t));
-    new_attribute->attribute_tag = CHARACTER;
-    new_attribute->attribute_value.char_val = value;
-    new_attribute->attribute_key = strndup(attr_name, 100);
 
     if (new_attribute == NULL) {
         fprintf(stderr, "Failed to allocate memory for new attribute");
         return NULL;
     }
+
+    new_attribute->attribute_tag = CHARACTER;
+    new_attribute->attribute_value.char_val = value;
+    new_attribute->attribute_key = strndup(attr_name, MAX_ID_LEN);
 
     return new_attribute;
 }
@@ -281,14 +285,15 @@ attribute_t* char_attr_new(char* attr_name, char value)
 attribute_t* bool_attr_new(char* attr_name, bool value)
 {
     attribute_t* new_attribute = malloc(sizeof(attribute_t));
-    new_attribute->attribute_tag = BOOLE;
-    new_attribute->attribute_value.bool_val = value;
-    new_attribute->attribute_key = strndup(attr_name, 100);
 
     if (new_attribute == NULL) {
         fprintf(stderr, "Failed to allocate memory for new attribute");
         return NULL;
     }
+    
+    new_attribute->attribute_tag = BOOLE;
+    new_attribute->attribute_value.bool_val = value;
+    new_attribute->attribute_key = strndup(attr_name, MAX_ID_LEN);
 
     return new_attribute;
 }

--- a/src/game-state/src/item.c
+++ b/src/game-state/src/item.c
@@ -208,126 +208,173 @@ attribute_t *get_attribute(item_t *item, char* attr_name)
     return return_value;
 }
 
+// TYPE-SPECIFIC ATTRIBUTE INITIALIZING FUNCTIONS -------------------------------------------
+/* see item.h */
+attribute_t* str_attr_new(char* attr_name, char* value)
+{
+    attribute_t* new_attribute = malloc(sizeof(attribute_t));
+    new_attribute->attribute_tag = STRING;
+    new_attribute->attribute_value.str_val = value;
+    new_attribute->attribute_key = strndup(attr_name, 100);
+
+    if (new_attribute == NULL) {
+        fprintf(stderr, "Failed to allocate memory for new attribute");
+        return NULL;
+    }
+
+    return new_attribute;
+}
+
+
+/* see item.h */
+attribute_t* int_attr_new(char* attr_name, int value)
+{
+    attribute_t* new_attribute = malloc(sizeof(attribute_t));
+    new_attribute->attribute_tag = INTEGER;
+    new_attribute->attribute_value.int_val = value;
+    new_attribute->attribute_key = strndup(attr_name, 100);
+
+    if (new_attribute == NULL) {
+        fprintf(stderr, "Failed to allocate memory for new attribute");
+        return NULL;
+    }
+
+    return new_attribute;
+}
+
+
+/* see item.h */
+attribute_t* double_attr_new(char* attr_name, double value)
+{
+    attribute_t* new_attribute = malloc(sizeof(attribute_t));
+    new_attribute->attribute_tag = DOUBLE;
+    new_attribute->attribute_value.double_val = value;
+    new_attribute->attribute_key = strndup(attr_name, 100);
+
+    if (new_attribute == NULL) {
+        fprintf(stderr, "Failed to allocate memory for new attribute");
+        return NULL;
+    }
+
+    return new_attribute;
+}
+
+
+/* see item.h */
+attribute_t* char_attr_new(char* attr_name, char value)
+{
+    attribute_t* new_attribute = malloc(sizeof(attribute_t));
+    new_attribute->attribute_tag = CHARACTER;
+    new_attribute->attribute_value.char_val = value;
+    new_attribute->attribute_key = strndup(attr_name, 100);
+
+    if (new_attribute == NULL) {
+        fprintf(stderr, "Failed to allocate memory for new attribute");
+        return NULL;
+    }
+
+    return new_attribute;
+}
+
+
+/* see item.h */
+attribute_t* bool_attr_new(char* attr_name, bool value)
+{
+    attribute_t* new_attribute = malloc(sizeof(attribute_t));
+    new_attribute->attribute_tag = BOOLE;
+    new_attribute->attribute_value.bool_val = value;
+    new_attribute->attribute_key = strndup(attr_name, 100);
+
+    if (new_attribute == NULL) {
+        fprintf(stderr, "Failed to allocate memory for new attribute");
+        return NULL;
+    }
+
+    return new_attribute;
+}
+
+
+// TYPE-SPECIFIC SET_ATTR FUNCTIONS -------------------------------------------
 
 /* see item.h */
 int set_str_attr(item_t* item, char* attr_name, char* value)
 {
     attribute_t* res = get_attribute(item, attr_name);
-    if (res == NULL)
-    {
-        attribute_t* new_attribute = malloc(sizeof(attribute_t));
-        new_attribute->attribute_tag = STRING;
-        new_attribute->attribute_value.str_val = value;
-        new_attribute->attribute_key = strndup(attr_name, 100);
+    if (res == NULL) {
+        attribute_t* new_attribute = str_attr_new(attr_name, value);
         int rv = add_attribute_to_hash(item, new_attribute);
         return rv;
-    }
-    else if (res != NULL && res->attribute_tag != STRING)
-    {
+    } else if (res != NULL && res->attribute_tag != STRING) {
         return FAILURE; // skeleton for not overriding type
-    }
-    else
-    {
+    } else {
         res->attribute_value.str_val = value;
         return SUCCESS;
     }
 }
 
-// TYPE-SPECIFIC SET_ATTR FUNCTIONS -------------------------------------------
+
 /* see item.h */
 int set_int_attr(item_t* item, char* attr_name, int value)
 {
     attribute_t* res = get_attribute(item, attr_name);
-    if (res == NULL)
-    {
-        attribute_t* new_attribute = malloc(sizeof(attribute_t));
-        new_attribute->attribute_tag = INTEGER;
-        new_attribute->attribute_value.int_val = value;
-        new_attribute->attribute_key = strndup(attr_name, 100);
+    if (res == NULL) {
+        attribute_t* new_attribute = int_attr_new(attr_name, value);
         int rv = add_attribute_to_hash(item, new_attribute);
         return rv;
-    }
-    else if (res != NULL && res->attribute_tag != INTEGER)
-    {
+    } else if (res != NULL && res->attribute_tag != INTEGER) {
         return FAILURE; // skeleton for not overriding type
-    }
-    else
-    {
+    } else {
         res->attribute_value.int_val = value;
         return SUCCESS;
     }
 }
 
+
 /* see item.h */
 int set_double_attr(item_t* item, char* attr_name, double value)
 {
     attribute_t* res = get_attribute(item, attr_name);
-    if (res == NULL)
-    {
-        attribute_t* new_attribute = malloc(sizeof(attribute_t));
-        new_attribute->attribute_tag = DOUBLE;
-        new_attribute->attribute_value.double_val = value;
-        new_attribute->attribute_key = strndup(attr_name, 100);
+    if (res == NULL) {
+        attribute_t* new_attribute = double_attr_new(attr_name, value);
         int rv = add_attribute_to_hash(item, new_attribute);
         return rv;
-    }
-    else if (res != NULL && res->attribute_tag != DOUBLE)
-    {
+    } else if (res != NULL && res->attribute_tag != DOUBLE) {
         return FAILURE; // skeleton for not overriding type
-    }
-    else
-    {
+    } else {
         res->attribute_value.double_val = value;
         return SUCCESS;
     }
-
 }
+
 
 /* see item.h */
 int set_char_attr(item_t* item, char* attr_name, char value)
 {
     attribute_t* res = get_attribute(item, attr_name);
-    if (res == NULL)
-    {
-        attribute_t* new_attribute = malloc(sizeof(attribute_t));
-        new_attribute->attribute_tag = CHARACTER;
-        new_attribute->attribute_value.char_val = value;
-        new_attribute->attribute_key = strndup(attr_name, 100);
+    if (res == NULL) {
+        attribute_t* new_attribute = char_attr_new(attr_name, value);
         int rv = add_attribute_to_hash(item, new_attribute);
         return rv;
-    }
-    else if (res != NULL && res->attribute_tag != CHARACTER)
-    {
+    } else if (res != NULL && res->attribute_tag != CHARACTER) {
         return FAILURE; // skeleton for not overriding type
-    }
-
-    else
-    {
+    } else {
         res->attribute_value.char_val = value;
         return SUCCESS;
     }
 }
 
+
 /* see item.h */
 int set_bool_attr(item_t* item, char* attr_name, bool value)
 {
     attribute_t* res = get_attribute(item, attr_name);
-    if (res == NULL)
-    {
-        attribute_t* new_attribute = malloc(sizeof(attribute_t));
-        new_attribute->attribute_tag = BOOLE;
-        new_attribute->attribute_value.bool_val = value;
-        new_attribute->attribute_key = strndup(attr_name, 100);
+    if (res == NULL) {
+        attribute_t* new_attribute = bool_attr_new(attr_name, value);
         int rv = add_attribute_to_hash(item, new_attribute);
         return rv;
-    }
-    else if (res != NULL && res->attribute_tag != BOOLE)
-    {
+    } else if (res != NULL && res->attribute_tag != BOOLE) {
         return FAILURE; // skeleton for not overriding type
-    }
-
-    else
-    {
+    } else {
         res->attribute_value.bool_val = value;
         return SUCCESS;
     }

--- a/src/playerclass/src/class_item_restriction.c
+++ b/src/playerclass/src/class_item_restriction.c
@@ -17,11 +17,7 @@ int add_item_restriction(item_t* item, class_t* class) {
         item->class_restrictions = create_list_attribute();
     }
 
-    /* Attribute creation will be refactored in game-state/item to allow for streamlined attribute creation */
-    attribute_t* restriction = malloc(sizeof(attribute_t));
-    restriction->attribute_tag = BOOLE;
-    restriction->attribute_value.bool_val = true;
-    restriction->attribute_key = strndup(class->name, 100);
+    attribute_t* restriction = bool_attr_new(class->name, true);
 
     if (restriction == NULL) {
         fprintf(stderr, "Failed to allocate memory in add_item_restriction");

--- a/tests/game-state/test_items.c
+++ b/tests/game-state/test_items.c
@@ -396,6 +396,65 @@ Test(attribute, get_attribute)
 
 // TESTS FOR TYPE-SPECIFIC ATTR_NEW() FUNCTIONS --------------------------------
 
+Test(attribute, str_attr_new)
+{
+    attribute_t *test_attr = str_attr_new("Attribute_Test_Name", "Attribute_Test_Value");
+
+    cr_assert_not_null(test_attr, "str_attr_new: null attribute returned");
+
+    cr_assert_str_eq(test_attr->attribute_value.str_val, "Attribute_Test_Value", 
+                     "str_attr_new: Attribute value not correctly set");
+
+    attribute_free(test_attr);
+}
+
+Test(attribute, int_attr_new)
+{
+    attribute_t *test_attr = int_attr_new("Attribute_Test_Name", 0);
+
+    cr_assert_not_null(test_attr, "int_attr_new: null attribute returned");
+
+    cr_assert_eq(test_attr->attribute_value.int_val, 0, 
+                 "int_attr_new: Attribute value not correctly set");
+
+    attribute_free(test_attr);
+}
+
+Test(attribute, double_attr_new)
+{
+    attribute_t *test_attr = double_attr_new("Attribute_Test_Name", 0.0);
+
+    cr_assert_not_null(test_attr, "double_attr_new: null attribute returned");
+
+    cr_assert_eq(test_attr->attribute_value.double_val, 0.0, 
+                 "double_attr_new: Attribute value not correctly set");
+
+    attribute_free(test_attr);
+}
+
+Test(attribute, char_attr_new)
+{
+    attribute_t *test_attr = char_attr_new("Attribute_Test_Name", 'a');
+
+    cr_assert_not_null(test_attr, "char_attr_new: null attribute returned");
+
+    cr_assert_eq(test_attr->attribute_value.char_val, 'a', 
+                 "char_attr_new: Attribute value not correctly set");
+
+    attribute_free(test_attr);
+}
+
+Test(attribute, bool_attr_new)
+{
+    attribute_t *test_attr = bool_attr_new("Attribute_Test_Name", true);
+
+    cr_assert_not_null(test_attr, "bool_attr_new: null attribute returned");
+
+    cr_assert_eq(test_attr->attribute_value.bool_val, true, 
+                     "int_attr_new: Attribute value not correctly set");
+
+    attribute_free(test_attr);
+}
 
 // TESTS FOR TYPE-SPECIFIC SET_ATTR() FUNCTIONS --------------------------------
 
@@ -408,7 +467,7 @@ Test(attribute, set_str_attr)
     cr_assert_eq(rv, SUCCESS, "change_str_attr: did not successfully set attr");
     int num_in_hash = HASH_COUNT(test_item->attributes);
     cr_assert_gt(num_in_hash, 0, "change_str_attr: no elements added to hash");
-    attribute_t* test_attr = get_attribute(test_item, "Attribute_Test_Name");
+     attribute_t* test_attr = get_attribute(test_item, "Attribute_Test_Name");
     cr_assert_not_null(test_attr, "change_str_attr: null attribute returned");
     char* test_str = test_attr->attribute_value.str_val;
     cr_assert_str_eq(test_str, "Attribute_Test_Value",

--- a/tests/game-state/test_items.c
+++ b/tests/game-state/test_items.c
@@ -467,7 +467,7 @@ Test(attribute, set_str_attr)
     cr_assert_eq(rv, SUCCESS, "change_str_attr: did not successfully set attr");
     int num_in_hash = HASH_COUNT(test_item->attributes);
     cr_assert_gt(num_in_hash, 0, "change_str_attr: no elements added to hash");
-     attribute_t* test_attr = get_attribute(test_item, "Attribute_Test_Name");
+    attribute_t* test_attr = get_attribute(test_item, "Attribute_Test_Name");
     cr_assert_not_null(test_attr, "change_str_attr: null attribute returned");
     char* test_str = test_attr->attribute_value.str_val;
     cr_assert_str_eq(test_str, "Attribute_Test_Value",

--- a/tests/game-state/test_items.c
+++ b/tests/game-state/test_items.c
@@ -394,6 +394,9 @@ Test(attribute, get_attribute)
 
 }
 
+// TESTS FOR TYPE-SPECIFIC ATTR_NEW() FUNCTIONS --------------------------------
+
+
 // TESTS FOR TYPE-SPECIFIC SET_ATTR() FUNCTIONS --------------------------------
 
 /* Checks creation of new string attribute and adding it to an item */


### PR DESCRIPTION
(Closes #851)

In the current class item restriction code, it is necessary to create an attribute directly in order to add it to the `class_restrictions` field of an item (a linked list of attributes). However, the code in `item.c` only contains type-specific `set_attr` functions that combine the creation of an attribute and its addition to the `attributes` hash table. Since class item restrictions are handled via a linked-list, not the `attributes` hash table, I divided up the two processes occurring in the `set_attr` functions in order to allow for creation of attributes in modules other than `game-state`.

Summary of Major Changes:

- Five type-specific attribute creation functions have been added to `item.c` 
- Relevant tests were added and documentation was updated
- Minor changes in `class_item_restriction.c` reflect the addition of these type-specific attribute creation functions
