### PR TITLE
Refactor level-oriented generation code

### DIFF
--- a/include/openworld/autogenerate.h
+++ b/include/openworld/autogenerate.h
@@ -195,6 +195,7 @@ int roomspec_is_given_difficulty(room_level_t **room_levels,
 
 /* filter_speclist_with_difficulty
  * Creates a speclist by filtering the given speclist with a difficulty level
+ * so that the returned speclist only contains roomspecs of one level
  *
  * Parameters:
  * - speclist: pointer to the speclist we want to filter

--- a/include/openworld/autogenerate.h
+++ b/include/openworld/autogenerate.h
@@ -193,6 +193,22 @@ int roomspec_is_given_difficulty(room_level_t **room_levels,
                                   int difficulty_level);
 
 
+/* filter_speclist_with_difficulty
+ * Creates a speclist by filtering the given speclist with a difficulty level
+ *
+ * Parameters:
+ * - speclist: pointer to the speclist we want to filter
+ * - room_levels: pointer to the hash structure for room levels
+ * - difficulty_level: the difficulty level
+ * 
+ * Returns:
+ * - pointer to the filtered speclist, NULL if no spec matches the level
+ */
+speclist_t* filter_speclist_with_difficulty(speclist_t *speclist, 
+                                            room_level_t **room_levels, 
+                                            int difficulty_level);
+
+
 /* multi_room_level_generate
  * Level-oriented version of multi_room_generate.
  *
@@ -201,6 +217,9 @@ int roomspec_is_given_difficulty(room_level_t **room_levels,
  * - context: pointer to a gencontext_t (type gencontext_t*). Not NULL.
  * - room_id: a unique room_id string for the to-be-generated room.i
  * - num_rooms: specifies how many new rooms will be generated
+ * - room_levels: pointer to the hash structure for room levels
+ * - level_scale: pointer to the scale for mapping player level 
+ *   to difficulty level
  *
  * Side effects:
  * - Changes input game to hold the newly generated room(s),

--- a/src/openworld/src/autogenerate.c
+++ b/src/openworld/src/autogenerate.c
@@ -228,6 +228,25 @@ int roomspec_is_given_difficulty(room_level_t **room_levels,
 
 
 /* See autogenerate.h */
+speclist_t* filter_speclist_with_difficulty(speclist_t *speclist, 
+                                            room_level_t **room_levels, 
+                                            int difficulty_level)
+{
+    speclist_t *tmp;
+    speclist_t *filtered_speclist = NULL;
+
+    DL_FOREACH(speclist, tmp) { 
+        if (roomspec_is_given_difficulty(room_levels, tmp->spec, difficulty_level) == SUCCESS) 
+        { 
+               DL_APPEND(filtered_speclist, tmp);    
+        }
+    }
+
+    return filtered_speclist;
+}
+
+
+/* See autogenerate.h */
 int multi_room_level_generate(game_t *game, gencontext_t *context, 
                               char *room_id, int num_rooms,
                               room_level_t **room_levels, 
@@ -242,14 +261,9 @@ int multi_room_level_generate(game_t *game, gencontext_t *context,
     int difficulty_level = map_level_to_difficulty(level_scale, context->level);
 
     /* filter the given speclist according to difficulty */
-    speclist_t *tmp;
-    speclist_t *filtered_speclist = NULL;
-
-    DL_FOREACH(context->speclist, tmp) { 
-        if (roomspec_is_given_difficulty(room_levels, tmp->spec, difficulty_level) == SUCCESS) { 
-               DL_APPEND(filtered_speclist, tmp);    
-        }
-    }
+    speclist_t *filtered_speclist = filter_speclist_with_difficulty(context->speclist, 
+                                                                    room_levels, 
+                                                                    difficulty_level);
 
     /* filtered gencontext */
     gencontext_t* filtered_context = gencontext_new(context->open_paths,

--- a/tests/openworld/test_autogenerate.c
+++ b/tests/openworld/test_autogenerate.c
@@ -1062,6 +1062,78 @@ Test(room_level, lvl0_to_lvl1_roomlevels)
 
 
 
+/* Checks that filter_speclist_with_difficulty returns NULL
+ * if no roomspec in the speclist is of the given difficulty level */
+Test(speclist, filter_speclist_NULL)
+{
+    roomspec_t *rspec1 = make_default_room("school", NULL, NULL);
+    roomspec_t *rspec2 = make_default_room("farmhouse", NULL, NULL);
+
+    speclist_t *list1 = speclist_new(rspec1);
+    speclist_t *list2 = speclist_new(rspec2);
+
+    cr_assert_not_null(list1, "failed to create new speclist_t\n");
+    cr_assert_not_null(list2, "failed to create new speclist_t\n");
+
+    speclist_t *unfiltered = NULL;
+
+    DL_APPEND(unfiltered, list1);
+    DL_APPEND(unfiltered, list2);
+
+    room_level_t *room_level = NULL;
+    
+    char *roomname_1 = rspec1->room_name;
+    char *roomname_2 = rspec2->room_name;
+
+    // label the rooms' level with 0
+    add_room_level_to_hash(&room_level, roomname_1, 0);
+    add_room_level_to_hash(&room_level, roomname_2, 0);
+
+    // filter the speclist with level 1
+    speclist_t* filtered = filter_speclist_with_difficulty(unfiltered, 
+                                                           &room_level, 
+                                                           1);
+
+    cr_assert_null(filtered, "filtered speclist should be NULL");
+}
+
+
+/* Checks that filter_speclist_with_difficulty successfully filters speclist */
+Test(speclist, filter_speclist)
+{
+    roomspec_t *rspec1 = make_default_room("school", NULL, NULL);
+    roomspec_t *rspec2 = make_default_room("farmhouse", NULL, NULL);
+
+    speclist_t *list1 = speclist_new(rspec1);
+    speclist_t *list2 = speclist_new(rspec2);
+
+    cr_assert_not_null(list1, "failed to create new speclist_t\n");
+    cr_assert_not_null(list2, "failed to create new speclist_t\n");
+
+    speclist_t *unfiltered = NULL;
+
+    DL_APPEND(unfiltered, list1);
+    DL_APPEND(unfiltered, list2);
+
+    room_level_t *room_level = NULL;
+    
+    char *roomname_1 = rspec1->room_name;
+    char *roomname_2 = rspec2->room_name;
+
+    // label the rooms' level with 0
+    add_room_level_to_hash(&room_level, roomname_1, 0);
+    add_room_level_to_hash(&room_level, roomname_2, 0);
+
+    // filter the speclist with level 0
+    speclist_t* filtered = filter_speclist_with_difficulty(unfiltered, 
+                                                           &room_level, 
+                                                           0);
+
+    cr_assert_not_null(filtered, "filtered speclist should not be NULL");
+}
+
+
+
 /* Checks that multi_room_level_generate returns FAILURE 
  * if the only room spec in the speclist is not of the right difficulty level */
 Test(autogenerate, invalid_multi_room_level_1)

--- a/tests/openworld/test_autogenerate.c
+++ b/tests/openworld/test_autogenerate.c
@@ -1066,8 +1066,8 @@ Test(room_level, lvl0_to_lvl1_roomlevels)
  * if no roomspec in the speclist is of the given difficulty level */
 Test(speclist, filter_speclist_NULL)
 {
-    roomspec_t *rspec1 = make_default_room("school", NULL, NULL);
-    roomspec_t *rspec2 = make_default_room("farmhouse", NULL, NULL);
+    roomspec_t *rspec1 = roomspec_new("room_name_1", "short_desc", "long_desc", NULL);
+    roomspec_t *rspec2 = roomspec_new("room_name_2", "short_desc", "long_desc", NULL);
 
     speclist_t *list1 = speclist_new(rspec1);
     speclist_t *list2 = speclist_new(rspec2);
@@ -1082,12 +1082,9 @@ Test(speclist, filter_speclist_NULL)
 
     room_level_t *room_level = NULL;
     
-    char *roomname_1 = rspec1->room_name;
-    char *roomname_2 = rspec2->room_name;
-
     // label the rooms' level with 0
-    add_room_level_to_hash(&room_level, roomname_1, 0);
-    add_room_level_to_hash(&room_level, roomname_2, 0);
+    add_room_level_to_hash(&room_level, "room_name_1", 0);
+    add_room_level_to_hash(&room_level, "room_name_2", 0);
 
     // filter the speclist with level 1
     speclist_t* filtered = filter_speclist_with_difficulty(unfiltered, 
@@ -1101,8 +1098,8 @@ Test(speclist, filter_speclist_NULL)
 /* Checks that filter_speclist_with_difficulty successfully filters speclist */
 Test(speclist, filter_speclist)
 {
-    roomspec_t *rspec1 = make_default_room("school", NULL, NULL);
-    roomspec_t *rspec2 = make_default_room("farmhouse", NULL, NULL);
+    roomspec_t *rspec1 = roomspec_new("room_name_1", "short_desc", "long_desc", NULL);
+    roomspec_t *rspec2 = roomspec_new("room_name_2", "short_desc", "long_desc", NULL);
 
     speclist_t *list1 = speclist_new(rspec1);
     speclist_t *list2 = speclist_new(rspec2);
@@ -1121,8 +1118,8 @@ Test(speclist, filter_speclist)
     char *roomname_2 = rspec2->room_name;
 
     // label the rooms' level with 0
-    add_room_level_to_hash(&room_level, roomname_1, 0);
-    add_room_level_to_hash(&room_level, roomname_2, 0);
+    add_room_level_to_hash(&room_level, "room_name_1", 0);
+    add_room_level_to_hash(&room_level, "room_name_2", 0);
 
     // filter the speclist with level 0
     speclist_t* filtered = filter_speclist_with_difficulty(unfiltered, 

--- a/tests/openworld/test_autogenerate.c
+++ b/tests/openworld/test_autogenerate.c
@@ -1082,11 +1082,11 @@ Test(speclist, filter_speclist_NULL)
 
     room_level_t *room_level = NULL;
     
-    // label the rooms' level with 0
+    /* label the rooms' level with 0 */
     add_room_level_to_hash(&room_level, "room_name_1", 0);
     add_room_level_to_hash(&room_level, "room_name_2", 0);
 
-    // filter the speclist with level 1
+    /* filter the speclist with level 1 */
     speclist_t* filtered = filter_speclist_with_difficulty(unfiltered, 
                                                            &room_level, 
                                                            1);
@@ -1100,33 +1100,44 @@ Test(speclist, filter_speclist)
 {
     roomspec_t *rspec1 = roomspec_new("room_name_1", "short_desc", "long_desc", NULL);
     roomspec_t *rspec2 = roomspec_new("room_name_2", "short_desc", "long_desc", NULL);
-
+    roomspec_t *rspec3 = roomspec_new("room_name_3", "short_desc", "long_desc", NULL);
+    
     speclist_t *list1 = speclist_new(rspec1);
     speclist_t *list2 = speclist_new(rspec2);
+    speclist_t *list3 = speclist_new(rspec3);
 
     cr_assert_not_null(list1, "failed to create new speclist_t\n");
     cr_assert_not_null(list2, "failed to create new speclist_t\n");
+    cr_assert_not_null(list3, "failed to create new speclist_t\n");
 
     speclist_t *unfiltered = NULL;
 
     DL_APPEND(unfiltered, list1);
     DL_APPEND(unfiltered, list2);
+    DL_APPEND(unfiltered, list3);
 
     room_level_t *room_level = NULL;
-    
-    char *roomname_1 = rspec1->room_name;
-    char *roomname_2 = rspec2->room_name;
 
-    // label the rooms' level with 0
-    add_room_level_to_hash(&room_level, "room_name_1", 0);
-    add_room_level_to_hash(&room_level, "room_name_2", 0);
+    /* label the rooms' level with 1, 2, 3 */
+    add_room_level_to_hash(&room_level, "room_name_1", 1);
+    add_room_level_to_hash(&room_level, "room_name_2", 2);
+    add_room_level_to_hash(&room_level, "room_name_3", 3);
 
-    // filter the speclist with level 0
+    /* filter the speclist with level 2 */
     speclist_t* filtered = filter_speclist_with_difficulty(unfiltered, 
                                                            &room_level, 
-                                                           0);
+                                                           2);
 
     cr_assert_not_null(filtered, "filtered speclist should not be NULL");
+
+    speclist_t *tmp;
+    int count;
+
+    DL_COUNT(filtered, tmp, count);
+    cr_assert_eq(count, 1, "there should be only one roomspec in the filter speclist");
+
+    cr_assert_str_eq(filtered->spec->room_name, "room_name_2", 
+                     "the filtered speclist should only contain rspec2"); 
 }
 
 


### PR DESCRIPTION
This Pull Request is for refactoring the level-oriented generation code, which puts the functionality of filtering a speclist with a difficulty level into a separate function so that the filtered speclist can be used for other level-oriented autogeneration functions in addition to multi_room_level_generate. 
This involves updating the autogenerate module. Tests are added to test_autogenerate.c. Updates in the autogenerate module include adding filter_speclist_with_difficulty function and modifying multi_room_level_generate function. 
This PR is related to issue #982.