### PR TITLE
Openworld Documentation

### DIFF
--- a/docs/openworld.md
+++ b/docs/openworld.md
@@ -11,14 +11,48 @@ The goal of the openworld module is to implement a feature that allows automatic
 
 ### chiventure/include/openworld
 Interface of openworld module
-- [autogenerate.h](https://github.com/uchicago-cs/chiventure/blob/dev/include/openworld/autogenerate.h) - Gathers room specifications from the default's and generates the room
+- [autogenerate.h](https://github.com/uchicago-cs/chiventure/blob/dev/include/openworld/autogenerate.h) - Gathers room specifications from the defaults and generates the room
 - [default_items.h](https://github.com/uchicago-cs/chiventure/blob/dev/include/openworld/default_items.h) - Contains a list of default items to be placed into the rooms during room generation
 - [default_rooms.h](https://github.com/uchicago-cs/chiventure/blob/dev/include/openworld/default_rooms.h) - Contains a list of default rooms from which autogenerate pulls the room info from during room generation
-- [gen_structs.h](https://github.com/uchicago-cs/chiventure/blob/dev/include/openworld/gen_structs.h) - Provides the structs that make generation work smoothly
+- [gen_structs.h](https://github.com/uchicago-cs/chiventure/blob/dev/include/openworld/gen_structs.h) - Provides the structs that make generation work smoothly:
+    - roomspec_t struct - Carries the necessary info for creating a room
+    typedef struct roomspec {
+        char *room_name;
+        char *short_desc;
+        char *long_desc;
+        int num_built;
+        item_hash_t *items;
+        UT_hash_handle hh;
+    } roomspec_t;
+    - speclist_t struct - Functions as a list of all the roomspec_t's
+    typedef struct speclist {
+        roomspec_t *spec;
+        struct speclist *prev;
+        struct speclist *next;
+    } speclist_t;
+    - gencontext_t struct - Carries the info for the generation algorithm
+    typedef struct gencontext {
+        path_t *open_paths;
+        int num_open_paths;
+        int level;
+        speclist_t *speclist;
+    } gencontext_t;
+    - roomlevel_t struct - Encode maps between difficulty/rooms needed for level-oriented generation
+    typedef struct roomlevel {
+        char *room_name;        
+        int difficulty_level;
+        UT_hash_handle hh;        
+    } roomlevel_t;
+    - levelspec_t struct - Carries all the info needed for level-oriented generatio
+    typedef struct levelspec {
+        roomlevel_t *roomlevels;
+        int num_thresholds;
+        int *thresholds;
+    } levelspec_t;
 
 ### chiventure/src/openworld
 Openworld source code
-- ./src
+- src/
     - [autogenerate.c](https://github.com/uchicago-cs/chiventure/blob/dev/src/openworld/src/autogenerate.c) - Implementation of autogenerate.h
     - [default_items.c](https://github.com/uchicago-cs/chiventure/blob/dev/src/openworld/src/default_items.c) - Implementation of default_items.h
     - [default_rooms.c](https://github.com/uchicago-cs/chiventure/blob/dev/src/openworld/src/default_rooms.c) - Implementation of default_rooms.h

--- a/docs/openworld.md
+++ b/docs/openworld.md
@@ -16,39 +16,10 @@ Interface of openworld module
 - [default_rooms.h](https://github.com/uchicago-cs/chiventure/blob/dev/include/openworld/default_rooms.h) - Contains a list of default rooms from which autogenerate pulls the room info from during room generation
 - [gen_structs.h](https://github.com/uchicago-cs/chiventure/blob/dev/include/openworld/gen_structs.h) - Provides the structs that make generation work smoothly:
     - roomspec_t struct - Carries the necessary info for creating a room
-    typedef struct roomspec {
-        char *room_name;
-        char *short_desc;
-        char *long_desc;
-        int num_built;
-        item_hash_t *items;
-        UT_hash_handle hh;
-    } roomspec_t;
     - speclist_t struct - Functions as a list of all the roomspec_t's
-    typedef struct speclist {
-        roomspec_t *spec;
-        struct speclist *prev;
-        struct speclist *next;
-    } speclist_t;
     - gencontext_t struct - Carries the info for the generation algorithm
-    typedef struct gencontext {
-        path_t *open_paths;
-        int num_open_paths;
-        int level;
-        speclist_t *speclist;
-    } gencontext_t;
     - roomlevel_t struct - Encode maps between difficulty/rooms needed for level-oriented generation
-    typedef struct roomlevel {
-        char *room_name;        
-        int difficulty_level;
-        UT_hash_handle hh;        
-    } roomlevel_t;
-    - levelspec_t struct - Carries all the info needed for level-oriented generatio
-    typedef struct levelspec {
-        roomlevel_t *roomlevels;
-        int num_thresholds;
-        int *thresholds;
-    } levelspec_t;
+    - levelspec_t struct - Carries all the info needed for level-oriented generation
 
 ### chiventure/src/openworld
 Openworld source code

--- a/docs/openworld.md
+++ b/docs/openworld.md
@@ -1,6 +1,6 @@
 # Openworld Documentation
 
-The goal of the openworld module is to implement a feature that allows automatic generation of rooms in chiventure.
+The goal of the openworld module is to implement a feature that allows automatic map/world generation in chiventure.
 
 ## Wiki Pages
 - [Source Document](https://github.com/uchicago-cs/chiventure/wiki/Open-World-~-Source-Document) - Implementation details about the openworld module
@@ -11,7 +11,7 @@ The goal of the openworld module is to implement a feature that allows automatic
 
 ### chiventure/include/openworld
 Interface of openworld module
-- [autogenerate.h](https://github.com/uchicago-cs/chiventure/blob/dev/include/openworld/autogenerate.h) - Gathers room specifications from the default's, generates the room, and then puts it directly into chiventure
+- [autogenerate.h](https://github.com/uchicago-cs/chiventure/blob/dev/include/openworld/autogenerate.h) - Gathers room specifications from the default's and generates the room
 - [default_items.h](https://github.com/uchicago-cs/chiventure/blob/dev/include/openworld/default_items.h) - Contains a list of default items to be placed into the rooms during room generation
 - [default_rooms.h](https://github.com/uchicago-cs/chiventure/blob/dev/include/openworld/default_rooms.h) - Contains a list of default rooms from which autogenerate pulls the room info from during room generation
 - [gen_structs.h](https://github.com/uchicago-cs/chiventure/blob/dev/include/openworld/gen_structs.h) - Provides the structs that make generation work smoothly

--- a/docs/openworld.md
+++ b/docs/openworld.md
@@ -1,0 +1,35 @@
+# Openworld Documentation
+
+The goal of the openworld module is to implement a feature that allows automatic generation of rooms in chiventure.
+
+## Wiki Pages
+- [Source Document](https://github.com/uchicago-cs/chiventure/wiki/Open-World-~-Source-Document) - Implementation details about the openworld module
+- [User Stories](https://github.com/uchicago-cs/chiventure/wiki/Open-World-~-User-Stories) - Product documentation for end-users on using openworld
+- [Feature Wishlist](https://github.com/uchicago-cs/chiventure/wiki/Open-World-~-Feature-Wishlist) - Summary of recent changes made to the openworld module and a list of potential new features to be implemented
+
+## Directories
+
+### chiventure/include/openworld
+Interface of openworld module
+- [autogenerate.h](https://github.com/uchicago-cs/chiventure/blob/dev/include/openworld/autogenerate.h) - Gathers room specifications from the default's, generates the room, and then puts it directly into chiventure
+- [default_items.h](https://github.com/uchicago-cs/chiventure/blob/dev/include/openworld/default_items.h) - Contains a list of default items to be placed into the rooms during room generation
+- [default_rooms.h](https://github.com/uchicago-cs/chiventure/blob/dev/include/openworld/default_rooms.h) - Contains a list of default rooms from which autogenerate pulls the room info from during room generation
+- [gen_structs.h](https://github.com/uchicago-cs/chiventure/blob/dev/include/openworld/gen_structs.h) - Provides the structs that make generation work smoothly
+
+### chiventure/src/openworld
+Openworld source code
+- ./src
+    - [autogenerate.c](https://github.com/uchicago-cs/chiventure/blob/dev/src/openworld/src/autogenerate.c) - Implementation of autogenerate.h
+    - [default_items.c](https://github.com/uchicago-cs/chiventure/blob/dev/src/openworld/src/default_items.c) - Implementation of default_items.h
+    - [default_rooms.c](https://github.com/uchicago-cs/chiventure/blob/dev/src/openworld/src/default_rooms.c) - Implementation of default_rooms.h
+    - [gen_structs.c](https://github.com/uchicago-cs/chiventure/blob/dev/src/openworld/src/gen_structs.c) - Implementation of gen_structs.h
+- [CMakeLists.txt](https://github.com/uchicago-cs/chiventure/blob/dev/src/openworld/CMakeLists.txt) - CMake file for openworld
+
+### chiventure/tests/openworld
+Openworld testing functions
+- [CMakeLists.txt](https://github.com/uchicago-cs/chiventure/blob/dev/tests/openworld/CMakeLists.txt)
+- [main.c](https://github.com/uchicago-cs/chiventure/blob/dev/tests/openworld/main.c)
+- [test_autogenerate.c](https://github.com/uchicago-cs/chiventure/blob/dev/tests/openworld/test_autogenerate.c)
+- [test_items.c](https://github.com/uchicago-cs/chiventure/blob/dev/tests/openworld/test_items.c)
+- [test_rooms.c](https://github.com/uchicago-cs/chiventure/blob/dev/tests/openworld/test_rooms.c)
+- [test_structs.c](https://github.com/uchicago-cs/chiventure/blob/dev/tests/openworld/test_structs.c)


### PR DESCRIPTION
Created a .md file for the openworld module for the chiventure/docs directory which contains:
- A brief description of the openworld module
- A list of wiki pages that include the system and product documentations of the openworld module
- A list of directories of the openworld module with a short description of each file's functionality

Since a feature wishlist [wiki page](https://github.com/uchicago-cs/chiventure/wiki/Open-World-~-Feature-Wishlist) already existed, we created a new [issue](https://github.com/uchicago-cs/chiventure/issues/1085) to update the wiki page with changes made to the openworld module this year and a list of potential new features to be implemented for next year.