### PR TITLE
Fixes last minute errors in the Action Management Demo Game

### DIFF
--- a/src/action_management/examples/spring2021-demo.c
+++ b/src/action_management/examples/spring2021-demo.c
@@ -58,7 +58,7 @@ char *raiseDmg(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
   attribute_t *dmgIncrease = int_attr_new("Dmg", 3);
   attribute_t *dmgCap = int_attr_new("Dmg", 15);
   
-  attribute_t *wepDmg = get_attribute(get_item_in_hash(ctx->game->curr_player->inventory, "A sword"), "Dmg");
+  attribute_t *wepDmg = get_attribute(get_item_in_hash(ctx->game->curr_player->inventory, "a sword"), "Dmg");
 
   args[0] = dmgIncrease;
   args[1] = wepDmg;
@@ -110,7 +110,7 @@ char *raiseDmg(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
 
 char *seeDmg(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
 {
-  int num =  get_attribute(get_item_in_hash(ctx->game->curr_player->inventory, "A sword"), "Dmg")->attribute_value.int_val;
+  int num =  get_attribute(get_item_in_hash(ctx->game->curr_player->inventory, "a sword"), "Dmg")->attribute_value.int_val;
   /* Weapon damage will never become 4 digits unless RAISEDMG is run over 300 times. */  
   char *str = malloc(sizeof(char) *4);
   sprintf(str, "%d", num);


### PR DESCRIPTION
The case desensitize update broke the command for getting an item from a hash, so the search was changed from "A sword" to "a sword". This allows for the get_item_in_hash function to properly find the item. 