### PR TITLE
Quests/move rewards

### DIFF
--- a/include/quests/quests_state.h
+++ b/include/quests/quests_state.h
@@ -58,7 +58,7 @@ stat_req_t *stat_req_new(int hp, int level);
  *
  * Returns: a pointer to the newly allocated task that is not completed
  */
-task_t *task_new(mission_t *mission, char *id);
+task_t *task_new(mission_t *mission, char *id, reward_t *reward);
 
 /* Creates a new quest struct (allocates memory)
  * 

--- a/include/quests/quests_state.h
+++ b/include/quests/quests_state.h
@@ -54,10 +54,11 @@ stat_req_t *stat_req_new(int hp, int level);
  * Parameters:
  * - mission: the mission to be completed for the quest
  * - id: the id of the achievement
- * 
+ * - reward: the reward of the achievement
+ *
  * Returns: a pointer to the newly allocated achievement that is not completed
  */
-achievement_t *achievement_new(mission_t *mission, char *id);
+achievement_t *achievement_new(mission_t *mission, char *id, reward_t *reward);
 
 /* Creates a new quest struct (allocates memory)
  * 
@@ -130,12 +131,13 @@ int stat_req_init(stat_req_t *stat_req, int xp, int level);
  * - achievement: an already allocated achievement
  * - mission: the mission to be completed for the achievement
  * - id: the id of the achievement
+ * - reward: the reward of the achievement
  * 
  * Returns:
  * - SUCCESS for successful init
  * - FAILURE for unsuccessful init
  */
-int achievement_init(achievement_t *achievement, mission_t *mission, char *id);
+int achievement_init(achievement_t *achievement, mission_t *mission, char *id, reward_t *reward);
 
 
 /* Initialize an already allocated quest struct
@@ -258,15 +260,17 @@ int fail_quest(quest_t *quest);
 
 /* Completes an achievement in a quest by checking if a given
  * achievement ID matches any incomplete achievements in the
- * appropriate level of the achievement tree.
+ * appropriate level of the achievement tree. Returns the reward
+ * of the completed achievement.
  * 
  * Parameters:
  * - quest: pointer to the quest
  * - id: the string identifier of the completed achievement
- *
+ *  
  * Returns:
- * - SUCCESS
- * - FAILURE
+ * - the achievement's reward item
+ * - NULL if the achievment is incomplete
+ * 
  */
 int complete_achievement(quest_t *quest, char *id);
 

--- a/include/quests/quests_state.h
+++ b/include/quests/quests_state.h
@@ -139,7 +139,6 @@ int stat_req_init(stat_req_t *stat_req, int xp, int level);
  */
 int task_init(task_t *task, mission_t *mission, char *id, reward_t *reward);
 
-x
 /* Initialize an already allocated quest struct
  *
  * Parameters:

--- a/include/quests/quests_state.h
+++ b/include/quests/quests_state.h
@@ -272,7 +272,7 @@ int fail_quest(quest_t *quest);
  * - NULL if the achievment is incomplete
  * 
  */
-int complete_achievement(quest_t *quest, char *id);
+reward_t *complete_achievement(quest_t *quest, char *id);
 
 /* Checks if a quest is completed
  * 

--- a/include/quests/quests_structs.h
+++ b/include/quests/quests_structs.h
@@ -61,16 +61,30 @@ typedef union mission {
 } mission_t;
 
 /* 
+ * This struct represents a reward for completing a quest.
+ *
+ * Components:
+ *  xp: an xp amount gained
+ *  item: an item gained
+ */
+typedef struct reward {
+   int xp;
+   item_t *item;
+} reward_t;
+
+/* 
  * This struct represents an achievement.
  * 
  * Components:
  *  mission: mission to be completed
  *  id: string identifier for the achievement
+ *  reward: reward for completing the achievement.
  *  completed: bool for if achievement is completed
  */
 typedef struct achievement {
     mission_t *mission;
     char *id;
+    reward_t *reward;
     bool completed;     //0 is not completed, 1 is completed
 } achievement_t;
 
@@ -89,18 +103,6 @@ typedef struct achievement_tree {
     struct achievement_tree *rsibling;
     struct achievement_tree *lmostchild;
 } achievement_tree_t;
-
-/* 
- * This struct represents a reward for completing a quest.
- *
- * Components:
- *  xp: an xp amount gained
- *  item: an item gained
- */
-typedef struct reward {
-   int xp;
-   item_t *item;
-} reward_t;
 
 /*
  * This struct represents a skill requirement for a quest.
@@ -146,4 +148,4 @@ typedef struct quest  {
 typedef struct quest quest_hash_t;
 
 
-#endif
+#endif 

--- a/src/quests/examples/quest-example.c
+++ b/src/quests/examples/quest-example.c
@@ -175,7 +175,7 @@ char *talk_to_npc(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
 }
 
 /* Get a big reward for finishing all the passive quests */
-quest_t *make_passive_quest(long int quest_id, reward_t *reward, stat_req_t *stat_req)
+quest_t *make_passive_quest(char *quest_id, reward_t *reward, stat_req_t *stat_req)
 {
     quest_t *quest = quest_new(quest_id, NULL, reward, stat_req);
 
@@ -195,9 +195,9 @@ quest_t *make_passive_quest(long int quest_id, reward_t *reward, stat_req_t *sta
     hundred_fifty_xp->a_mission = NULL;
     hundred_fifty_xp->p_mission = p_mission3;
 
-    achievement_t *achievement1 = achievement_new(fifty_xp, "Get 50 xp");
-    achievement_t *achievement2 = achievement_new(hundred_xp, "Get 100 xp");
-    achievement_t *achievement3 = achievement_new(hundred_fifty_xp, "Get 150 xp");
+    achievement_t *achievement1 = achievement_new(fifty_xp, "Get 50 xp", NULL);
+    achievement_t *achievement2 = achievement_new(hundred_xp, "Get 100 xp", NULL);
+    achievement_t *achievement3 = achievement_new(hundred_fifty_xp, "Get 150 xp", NULL);
 
     add_achievement_to_quest(quest, achievement1, "The first mission");
     add_achievement_to_quest(quest, achievement2, "Get 50 xp");
@@ -206,7 +206,7 @@ quest_t *make_passive_quest(long int quest_id, reward_t *reward, stat_req_t *sta
     return quest;
 }
 
-quest_t *make_sample_quest(long int quest_id, reward_t *reward, stat_req_t *stat_req,
+quest_t *make_sample_quest(char *quest_id, reward_t *reward, stat_req_t *stat_req,
                            npc_t *npc1, npc_t *npc2, item_t *item1, item_t *item2,
                            room_t *room3, room_t *room4)
 {
@@ -305,13 +305,13 @@ int main(int argc, char **argv)
 
     stat_req_t *stat_req = stat_req_new(5, 2);
 
-    quest_t *quest = make_sample_quest(1, reward_if_kill, stat_req, npc1, npc2, item1, item2, third_room, last_room);
+    quest_t *quest = make_sample_quest("Quest 0", reward_if_kill, stat_req, npc1, npc2, item1, item2, third_room, last_room);
 
     reward_t *reward_passive = reward_new(0, item_new("Portal Gun", "this gun can create portals on special walls",
     "Reward for completing passive missions."));
 
     stat_req_t *stat_req_passive = stat_req_new(0, 0);
-    quest_t *quest_passive = make_passive_quest(1, reward_passive, stat_req_passive);
+    quest_t *quest_passive = make_passive_quest("Quest 1", reward_passive, stat_req_passive);
     /*quest layout: start in room1 -> go to room2 -> go to room3 -> get emerald -> go to room4 -> fight wolf and WIN -> get potion -> meet npc for reward
                                                                                                 / |
                                                                                                /  |

--- a/src/quests/examples/quest-example.c
+++ b/src/quests/examples/quest-example.c
@@ -243,12 +243,12 @@ quest_t *make_sample_quest(char *quest_id, reward_t *reward, stat_req_t *stat_re
     negotiate->a_mission = a_mission6;
     negotiate->p_mission = NULL;
 
-    achievement_t *achievement1 = achievement_new(meet_npc, "Meet the NPC quest giver");
-    achievement_t *achievement2 = achievement_new(get_emerald, "Get the emerald");
-    achievement_t *achievement3 = achievement_new(go_to_room4, "Go to room 4");
-    achievement_t *achievement4 = achievement_new(fight_wolf, "Fight the wolf");
-    achievement_t *achievement5 = achievement_new(die_to_wolf, "Die to wolf");
-    achievement_t *achievement6 = achievement_new(negotiate, "Negotiate with wolf");
+    achievement_t *achievement1 = achievement_new(meet_npc, "Meet the NPC quest giver", NULL);
+    achievement_t *achievement2 = achievement_new(get_emerald, "Get the emerald", NULL);
+    achievement_t *achievement3 = achievement_new(go_to_room4, "Go to room 4", NULL);
+    achievement_t *achievement4 = achievement_new(fight_wolf, "Fight the wolf", NULL);
+    achievement_t *achievement5 = achievement_new(die_to_wolf, "Die to wolf", NULL);
+    achievement_t *achievement6 = achievement_new(negotiate, "Negotiate with wolf", NULL);
 
     add_achievement_to_quest(quest, achievement1, "The first mission");
     add_achievement_to_quest(quest, achievement2, "Meet the NPC quest giver");

--- a/src/quests/src/quests_state.c
+++ b/src/quests/src/quests_state.c
@@ -496,7 +496,7 @@ int add_quest_to_hash(quest_t *quest, quest_hash_t *hash_table)
     quest_t *check;
 
     char buffer[MAX_ID_LEN];
-    sprintf(buffer, "%ld", quest->quest_id); //need to convert quest_ids to char *
+    sprintf(buffer, "%s", quest->quest_id); //need to convert quest_ids to char *
     
     check = get_quest_from_hash(buffer, hash_table);
 

--- a/src/quests/src/quests_state.c
+++ b/src/quests/src/quests_state.c
@@ -71,13 +71,13 @@ stat_req_t *stat_req_new(int xp, int level)
 }
 
 /* Refer to quests_state.h */
-achievement_t *achievement_new(mission_t *mission, char *id)
+achievement_t *achievement_new(mission_t *mission, char *id, reward_t *reward)
 {
     achievement_t *achievement;
     int rc;
     achievement = malloc(sizeof(achievement_t));
 
-    rc = achievement_init(achievement,mission, id);
+    rc = achievement_init(achievement,mission, id, reward);
     if (rc != SUCCESS)
     {
         fprintf(stderr, "\nCould not initialize achievement struct!\n");
@@ -159,11 +159,12 @@ int stat_req_init(stat_req_t *stat_req, int hp, int level)
 }
 
 /* Refer to quests_state.h */
-int achievement_init(achievement_t *achievement, mission_t *mission, char *id)
+int achievement_init(achievement_t *achievement, mission_t *mission, char *id, reward_t *reward)
 {
     assert(achievement != NULL);
 
     achievement->mission = mission;
+    achievement->reward = reward;
     achievement->completed = 0;
     achievement->id = id;
 
@@ -432,7 +433,7 @@ achievement_t *find_achievement(achievement_tree_t *tree, char *id)
 }
 
 /* Refer to quests_state.h */
-int complete_achievement(quest_t *quest, char *id)
+reward_t *complete_achievement(quest_t *quest, char *id)
 {
     achievement_tree_t *tree = quest->achievement_tree;
 
@@ -442,11 +443,11 @@ int complete_achievement(quest_t *quest, char *id)
             (achievement->completed == 0))
     {
         quest->achievement_tree->achievement->completed = 1;
-        return SUCCESS;
+        return achievement->reward;
     }
     else
     {
-        return FAILURE;
+        return NULL;
     }
 }
 

--- a/tests/quests/test_quests_state.c
+++ b/tests/quests/test_quests_state.c
@@ -480,7 +480,7 @@ Test(quest, complete_achievement)
     cr_assert_eq(res, SUCCESS, "add_achievement_to_quest() failed!");
 
     reward_t *new_reward = complete_achievement(quest, "test mission");
-    if (*new_reward == NULL)
+    if (new_reward == NULL)
         res = FAILURE;
 
     cr_assert_eq(res, SUCCESS, "complete_achievement() failed!");

--- a/tests/quests/test_quests_state.c
+++ b/tests/quests/test_quests_state.c
@@ -88,6 +88,7 @@ Test(achievement, init)
 
     item_t *item = item_new("reward_item", "item for rewarding",
     "test item for item_new()");
+    int xp = 40;
     reward_t *rewards = reward_new(xp, item);
 
     achievement_t *achievement = malloc(sizeof(achievement_t));
@@ -177,6 +178,7 @@ Test(achievement, new)
 
     item_t *item = item_new("reward_item", "item for rewarding",
     "test item for item_new()");
+    int xp = 40;
     reward_t *rewards = reward_new(xp, item);
 
 	achievement_t* achievement = achievement_new(mission, id, rewards);
@@ -231,6 +233,7 @@ Test(achievement, free)
 
     item_t *item = item_new("reward_item", "item for rewarding",
     "test item for item_new()");
+    int xp = 30;
     reward_t *rewards = reward_new(xp, item);
 
 	achievement_t* achievement_to_free = achievement_new(mission, id, rewards);
@@ -476,7 +479,9 @@ Test(quest, complete_achievement)
 
     cr_assert_eq(res, SUCCESS, "add_achievement_to_quest() failed!");
 
-    res = complete_achievement(quest, "test mission");
+    reward_t *new_reward = complete_achievement(quest, "test mission");
+    if (*new_reward == NULL)
+        res = FAILURE;
 
     cr_assert_eq(res, SUCCESS, "complete_achievement() failed!");
 }

--- a/tests/quests/test_quests_state.c
+++ b/tests/quests/test_quests_state.c
@@ -528,7 +528,9 @@ Test(quest,is_quest_completed)
 
     int res = add_task_to_quest(quest, task, NULL);
 
-    res = complete_task(quest, "mission");
+    reward_t *the_reward = complete_task(quest, "mission");
+    if (the_reward == NULL)
+        res = FAILURE;
 
     res = is_quest_completed(quest);
 

--- a/tests/quests/test_quests_state.c
+++ b/tests/quests/test_quests_state.c
@@ -86,9 +86,13 @@ Test(achievement, init)
     mission->a_mission = a_mission;
     mission->p_mission = NULL;
 
+    item_t *item = item_new("reward_item", "item for rewarding",
+    "test item for item_new()");
+    reward_t *rewards = reward_new(xp, item);
+
     achievement_t *achievement = malloc(sizeof(achievement_t));
 
-	int check = achievement_init(achievement, mission, id);
+	int check = achievement_init(achievement, mission, id, rewards);
 
 	cr_assert_eq(check, SUCCESS, "achievement_init() test has failed!");
 }
@@ -171,7 +175,11 @@ Test(achievement, new)
     mission->a_mission = a_mission;
     mission->p_mission = NULL;
 
-	achievement_t* achievement = achievement_new(mission, id);
+    item_t *item = item_new("reward_item", "item for rewarding",
+    "test item for item_new()");
+    reward_t *rewards = reward_new(xp, item);
+
+	achievement_t* achievement = achievement_new(mission, id, rewards);
 
 	cr_assert_not_null(achievement, "achievement_new() test has failed!");
 
@@ -221,7 +229,11 @@ Test(achievement, free)
     mission->a_mission = a_mission;
     mission->p_mission = NULL;
 
-	achievement_t* achievement_to_free = achievement_new(mission, id);
+    item_t *item = item_new("reward_item", "item for rewarding",
+    "test item for item_new()");
+    reward_t *rewards = reward_new(xp, item);
+
+	achievement_t* achievement_to_free = achievement_new(mission, id, rewards);
 
 	cr_assert_not_null(achievement_to_free, "achievement_free(): room is null");
 
@@ -348,7 +360,7 @@ Test(quest, add_achievement_to_quest)
     mission->a_mission = a_mission;
     mission->p_mission = NULL;
 
-	achievement_t* achievement_to_add = achievement_new(mission, id);
+	achievement_t* achievement_to_add = achievement_new(mission, id, rewards);
 
     int res = add_achievement_to_quest(quest, achievement_to_add, "NULL");
 
@@ -458,7 +470,7 @@ Test(quest, complete_achievement)
     mission->a_mission = a_mission;
     mission->p_mission = NULL;
 
-	achievement_t* achievement_to_complete = achievement_new(mission, id);
+	achievement_t* achievement_to_complete = achievement_new(mission, id, rewards);
 
     int res = add_achievement_to_quest(quest, achievement_to_complete, "NULL");
 
@@ -504,7 +516,7 @@ Test(quest,is_quest_completed)
     mission_t *mission = malloc(sizeof(mission_t));
     mission->a_mission = a_mission;
     mission->p_mission = NULL;
-    achievement_t *achievement = achievement_new(mission, "mission");
+    achievement_t *achievement = achievement_new(mission, "mission", rewards);
 
     int res = add_achievement_to_quest(quest, achievement, NULL);
 


### PR DESCRIPTION
The reward struct is placed earlier than the achievement struct and achievements are given the ability to contain rewards in order to increase the flexibility of rewards for completing quests through different paths. Code is modified and tests/examples were altered to work with the new achievement struct.