### PR TITLE
Fixed warnings associated with specgraph function from pull request #1384

### DIFF
--- a/include/openworld/gen_structs.h
+++ b/include/openworld/gen_structs.h
@@ -72,7 +72,7 @@ typedef struct roomspec rspec_hash_t;
  * The struct contains:
  * - int num_roomspecs: The number of different roomspecs available in the game
  * - roomspec_t roomspecs: list of pointers to roomspecs corresponding to each node on specgraph
- * - int **edges: Edges of graph representing the relationship between each roomspec (i.e. the adjacency matrix).
+ * - int *edges: Edges of graph representing the relationship between each roomspec (i.e. the adjacency matrix).
  *                These values will range from 0-5 and will be used to determine, for a room generated using the  
  *                room_autogenerate function, the probability that the roomspec associated with the newly generated 
  *                room will be a given roomspec. Thus, the higher the number, the more likely rooms of those roomspec 
@@ -82,7 +82,7 @@ typedef struct roomspec rspec_hash_t;
 typedef struct specgraph {
     int num_roomspecs;
     roomspec_t **roomspecs;
-    int **edges;
+    int *edges;
 } specgraph_t;
 
 /* gencontext_t struct
@@ -303,13 +303,13 @@ int roomspec_free(roomspec_t *spec);
 * - specgraph_t *specgraph: the pointer to the specgraph_t we are initializing
 * - int num_roomspecs: the number of roomspecs in the graph
 * - roomspec_t **roomspecs: An array of pointers to the roomspecs 
-* - int **edges: A 2D array representing the weights in the adjacency matrix
+* - int *edges: A 2D array representing the weights in the adjacency matrix
 *
 * returns:
 * SUCCESS - for SUCCESS
 * FAILURE - if failed to initialize
 */
-int specgraph_init(specgraph_t *specgraph, int num_roomspecs, roomspec_t **roomspecs, int **edges);
+int specgraph_init(specgraph_t *specgraph, int num_roomspecs, roomspec_t **roomspecs, int *edges);
 
 /* specgraph_new
 * Creates a new heap-allocated specgraph_t struct with the given paramaters.
@@ -317,13 +317,13 @@ int specgraph_init(specgraph_t *specgraph, int num_roomspecs, roomspec_t **rooms
 * parameters:
 * - int num_roomspecs: the number of roomspecs in the graph
 * - roomspec_t **roomspecs: An array of pointers to the roomspecs 
-* - int **edges: A 2D array representing the weights in the adjacency matrix
+* - int *edges: A 2D array representing the weights in the adjacency matrix
 *
 * returns:
 * specgraph_t *specgraph = the new specgraph
 * NULL - if failed to create a specgraph
 */
-specgraph_t* specgraph_new(int num_roomspecs, roomspec_t **roomspecs, int **edges);
+specgraph_t* specgraph_new(int num_roomspecs, roomspec_t **roomspecs, int *edges);
 
 /* specgraph_free
 * Frees a specgraph_t struct and all associated memory and returns whether or not it was successful

--- a/src/openworld/src/gen_structs.c
+++ b/src/openworld/src/gen_structs.c
@@ -192,7 +192,7 @@ roomspec_t* roomspec_new(char *room_name, char *short_desc, char *long_desc, ite
 }
 
 /* see gen_structs.h */
-int specgraph_init(specgraph_t *specgraph, int num_roomspecs, roomspec_t **roomspecs, int **edges)
+int specgraph_init(specgraph_t *specgraph, int num_roomspecs, roomspec_t **roomspecs, int *edges)
 {
     if (specgraph == NULL)
         return FAILURE;
@@ -204,7 +204,7 @@ int specgraph_init(specgraph_t *specgraph, int num_roomspecs, roomspec_t **rooms
 }
 
 /* see gen_structs.h */
-specgraph_t* specgraph_new(int num_roomspecs, roomspec_t **roomspecs, int **edges)
+specgraph_t* specgraph_new(int num_roomspecs, roomspec_t **roomspecs, int *edges)
 {
     specgraph_t *specnew = (specgraph_t*)malloc(sizeof(specgraph_t));
 
@@ -224,18 +224,9 @@ int specgraph_free(specgraph_t *specgraph)
         return FAILURE;
     //Free the roomspecs
     int num_roomspecs=specgraph->num_roomspecs;
-    for(int i=0; i<num_roomspecs; i++){
+    for(int i=0; i<num_roomspecs; i++)
         free((specgraph->roomspecs)[i]);
-    }
-    //free(specgraph->roomspecs);
-
-    //Free the adjacency matrix
-    /*for(int i=0; i<num_roomspecs; i++){
-        free((specgraph->edges)[i]);
-    }
-    free(specgraph->edges); */
-
-    //Free specgraph itself
+    
     free(specgraph);
 
     return SUCCESS;


### PR DESCRIPTION
We fixed the warnings that were caused by our new specgraph functions.

Specifically, we recognized that the edges field in the specgraph struct was causing the warnings. This is because we wanted to make edges a 2D array, but accidently made it an int** instead of an int*. We have now changed edges to an int* in all instances in gen_structs.h and gen_structs.c.