### PR TITLE
Created a new battle_item_t fields and a new battle_equipment_t data structure in battles

### DIFF
--- a/include/battle/battle_common.h
+++ b/include/battle/battle_common.h
@@ -55,6 +55,9 @@ typedef enum battle_status
  * moves: pointer to moves module (stub)
  * items: pointer to battle items module (stub)
  * ai: combatant's ai move strategy
+ * weapon: the weapon the combatant is holding
+ * accessory: the accessory the combatant is holding
+ * armor: the armor the combatant is holding
  * next: allows for combatant lists using utlist.h
  * prev: allows for combatant lists using utlist.h
  */
@@ -67,6 +70,9 @@ typedef struct combatant
     move_t *moves;
     battle_item_t *items;
     difficulty_t ai;
+    battle_equipment_t *weapon;
+    battle_equipment_t *accessory;
+    battle_equipment_t *armor;
     struct combatant *next;
     struct combatant *prev;
 } combatant_t;

--- a/include/battle/battle_default_objects.h
+++ b/include/battle/battle_default_objects.h
@@ -39,7 +39,7 @@ battle_item_t *get_random_offensive item();
  * Returns:
  *  - a pointer to the weapon
  */
-battle_equipment_t *get_random_equip_weapon()
+battle_equipment_t *get_random_equip_weapon();
 
 /* 
  * Generates a piece of armor equipment from a previously-initialized 
@@ -49,7 +49,7 @@ battle_equipment_t *get_random_equip_weapon()
  * Returns:
  *  - a pointer to the armor
  */
-battle_equipment_t *get_random_equip_armor()
+battle_equipment_t *get_random_equip_armor();
 
 /* 
  * Generates a piece of accessory equipment from a previously-initialized 
@@ -59,7 +59,7 @@ battle_equipment_t *get_random_equip_armor()
  * Returns:
  *  - a pointer to the accessory
  */
-battle_equipment_t *get_random_equip_accessory()
+battle_equipment_t *get_random_equip_accessory();
 
 /*
  * Generates a random consumable item from a list of previously-initialized consumables

--- a/include/battle/battle_default_objects.h
+++ b/include/battle/battle_default_objects.h
@@ -29,7 +29,7 @@ int randnum(int min, int max);
  * Returns:
  * -a pointer to a default battle weapon
  */
-battle_item_t *get_random_offensive item();
+battle_item_t *get_random_offensive_item();
 
 /* 
  * Generates a random piece of weapon equipment from a previously-initialized 

--- a/include/battle/battle_default_objects.h
+++ b/include/battle/battle_default_objects.h
@@ -23,6 +23,45 @@
 int randnum(int min, int max);
 
 /*
+ * Generates a random battle weapon from a list of previously-initialized moves
+ *
+ * parameters: none
+ * Returns:
+ * -a pointer to a default battle weapon
+ */
+battle_item_t *get_random_offensive item();
+
+/* 
+ * Generates a random piece of weapon equipment from a previously-initialized 
+ * list.
+ *
+ * Parameters: None
+ * Returns:
+ *  - a pointer to the weapon
+ */
+battle_equipment_t *get_random_equip_weapon()
+
+/* 
+ * Generates a piece of armor equipment from a previously-initialized 
+ * list.
+ *
+ * Parameters: None
+ * Returns:
+ *  - a pointer to the armor
+ */
+battle_equipment_t *get_random_equip_armor()
+
+/* 
+ * Generates a piece of accessory equipment from a previously-initialized 
+ * list.
+ *
+ * Parameters: None
+ * Returns:
+ *  - a pointer to the accessory
+ */
+battle_equipment_t *get_random_equip_accessory()
+
+/*
  * Generates a random consumable item from a list of previously-initialized consumables
  *
  * Parameters: none
@@ -30,15 +69,6 @@ int randnum(int min, int max);
  * - a pointer to a default item
  */
 battle_item_t *get_random_default_consumable();
-
-/*
- * Generates a random battle weapon from a list of previously-initialized moves
- * 
- * parameters: none
- * Returns:
- * -a pointer to a default battle weapon
- */
-battle_item_t *get_random_default_weapon(); 
 
 /*
  * Generates a random move from a list of previously-initialized moves

--- a/include/battle/battle_flow.h
+++ b/include/battle/battle_flow.h
@@ -148,17 +148,6 @@ char *battle_flow_list(battle_ctx_t *ctx, char* label);
 char *enemy_make_move(battle_ctx_t *ctx);
 
 /*
- * Applies stat changes to a target.
- * 
- * Parameters: 
- *  - changes: the stat changes
- *  - target_stats: the stats to be changes
- * Returns:
- *  - Always success
- */
-int apply_stat_changes(stat_t* target_stats, stat_changes_t* changes);
-
-/*
  * Uses a stat changing move. Works for stat changes
  * that affect the player, opponent, or both.
  * 

--- a/include/battle/battle_flow_structs.h
+++ b/include/battle/battle_flow_structs.h
@@ -12,11 +12,14 @@
 /* Stub for the player struct in game-state */
 typedef struct battle_player {
     // Other fields: hash handle, inventory, other stats
-    char *player_id;
-    class_t *class_type;
-    stat_t *stats;
-    move_t *moves;
-    battle_item_t *items;
+    char *player_id; // the user's ID
+    class_t *class_type; // the class of the user
+    stat_t *stats; // the stats the user has
+    move_t *moves; // the moves the user had
+    battle_item_t *items; // the items the user holds
+    battle_equipment_t *weapon;  // the weapon the user holds
+    battle_equipment_t *accessory; // the accessory the user holds
+    battle_equipment_t *armor; // the armor the user holds
 } battle_player_t;
 
 /* Stub for the game_t struct in game-state */

--- a/include/battle/battle_flow_structs.h
+++ b/include/battle/battle_flow_structs.h
@@ -48,6 +48,9 @@ typedef struct battle_ctx {
  *     - stats: player stats stub
  *     - moves: player moves stub
  *     - items: player battle_items stub
+ *     - weapon: the player's equiped weapon
+ *     - accessory: the player's equiped accessory
+ *     - armor: the player's equiped armor
  *
  * Returns: a newly allocated battle_player_t with p_id, stats, moves, battle_items
  */

--- a/include/battle/battle_flow_structs.h
+++ b/include/battle/battle_flow_structs.h
@@ -51,7 +51,11 @@ typedef struct battle_ctx {
  *
  * Returns: a newly allocated battle_player_t with p_id, stats, moves, battle_items
  */
-battle_player_t *new_ctx_player(char* p_id, class_t *class, stat_t *stats, move_t *moves, battle_item_t* items);
+battle_player_t *new_ctx_player(char* p_id, class_t *class, stat_t *stats, 
+                                move_t *moves, battle_item_t* items,
+                                battle_equipment_t *weapon, 
+                                battle_equipment_t *accessory, 
+                                battle_equipment_t *armor);
 
 /* Stub for the game_new function in game.h game-state module
  *

--- a/include/battle/battle_logic.h
+++ b/include/battle/battle_logic.h
@@ -99,6 +99,17 @@ int remove_battle_item(combatant_t *c, battle_item_t *item);
  */
 int award_xp(stat_t *stats, double xp);
 
+/*
+ * Applies stat changes to a target.
+ * 
+ * Parameters: 
+ *  - changes: the stat changes
+ *  - target_stats: the stats to be changes
+ * Returns:
+ *  - Always success
+ */
+int apply_stat_changes(stat_t* target_stats, stat_changes_t* changes);
+
 /* Adds new temporary status changes from an item. Note: Does
  *     not yet change the number of turns left, because items
  *     do not have that supported yet.

--- a/include/battle/battle_print.h
+++ b/include/battle/battle_print.h
@@ -109,6 +109,17 @@ char *print_start_turn(battle_t* b);
  */ 
 int *print_battle_items(battle_t *b, char *string);
 
+/* Concatenates a string of a full detail of the given
+ * battle item, including its full stat changes, description,
+ * and quantity.
+ * Parameter:
+ *  - item = pointer to the specific battle item
+ *  - string = the string the list will be concatenated to
+ * Returns:
+ *  SUCCESS if it succeeds
+ */ 
+int *print_battle_item_details(battle_item_t *item, char *string);
+
 /* Returns a string for the avaliable moves for the player
  * Parameter:
  *  - b = pointer to the battle

--- a/include/battle/battle_state.h
+++ b/include/battle/battle_state.h
@@ -46,12 +46,15 @@ int battle_free(battle_t *b);
  * - stats: pointer to the stats of the combatant(stub)
  * - moves: pointer to the linked list of moves for the combatant (stub)
  * - items: pointer to the linked list of battle_items for the combatant (stub)
+ * - weapon: a pointer to the weapon equiped to the combatant
+ * - accessory: a pointer to the accessory equiped to the combatant
+ * - armor: a pointer to the weapon equiped to the combatant
  * - ai: combatant's ai move strategy
  * returns: a pointer to the new character
  */
 combatant_t *combatant_new(char *name, bool is_friendly, class_t *c_type,
             stat_t *stats, move_t *moves, battle_item_t *items, battle_equipment_t *weapon, 
-            battle_equipment_t *accessory, battle_equipment_t *armor,difficulty_t ai);
+            battle_equipment_t *accessory, battle_equipment_t *armor, difficulty_t ai);
 
 /* Creates a new combatant struct
  * Parameters:
@@ -62,6 +65,9 @@ combatant_t *combatant_new(char *name, bool is_friendly, class_t *c_type,
  * - stats: a pointer to the stats of the combatant (stub)
  * - moves: a pointer to the linked list of moves for the combatant (stub)
  * - items: a pointer to the linked list of battle_items for the combatant (stub)
+ * - weapon: a pointer to the weapon equiped to the combatant
+ * - accessory: a pointer to the accessory equiped to the combatant
+ * - armor: a pointer to the weapon equiped to the combatant
  * - ai: combatant's ai move strategy
  * returns:
  * - SUCCESS for successful init

--- a/include/battle/battle_state.h
+++ b/include/battle/battle_state.h
@@ -50,7 +50,8 @@ int battle_free(battle_t *b);
  * returns: a pointer to the new character
  */
 combatant_t *combatant_new(char *name, bool is_friendly, class_t *c_type,
-             stat_t *stats, move_t *moves, battle_item_t *items, difficulty_t ai);
+            stat_t *stats, move_t *moves, battle_item_t *items, battle_equipment_t *weapon, 
+            battle_equipment_t *accessory, battle_equipment_t *armor,difficulty_t ai);
 
 /* Creates a new combatant struct
  * Parameters:
@@ -67,7 +68,8 @@ combatant_t *combatant_new(char *name, bool is_friendly, class_t *c_type,
  * - FAILURE for unsuccessful init
  */
 int combatant_init(combatant_t *c, char *name, bool is_friendly, class_t *c_type,
-     stat_t *stats, move_t *moves, battle_item_t *items, difficulty_t ai);
+     stat_t *stats, move_t *moves, battle_item_t *items, battle_equipment_t *weapon, 
+     battle_equipment_t *accessory, battle_equipment_t *armor, difficulty_t ai);
 
 /* Frees a combatant struct from memory
  * Parameters:

--- a/include/battle/battle_structs.h
+++ b/include/battle/battle_structs.h
@@ -6,34 +6,6 @@
 #include "playerclass/class_structs.h"
 #include "playerclass/class.h"
 
-/* Defines the type of equipment a piece of equipment is */
-enum equipment_type{
-    ACCESSORY,
-    ARMOR,
-    WEAPON
-};
-
-/* A data structure of a piece of equipment */ 
-typedef struct battle_equipment{
-    int id; // the id of the equipment, should be unique for each individual type of equipment.
-    char *name; // the name of the equipment
-    char *description; // the description of the equipment
-    stat_changes_t *attributes; // the stats that are changed by the equipment
-    equipment_type type; // determines the type of equipment (armor, weapon, accessory)
-} battle_equipment_t;
-
-/* This defines battle items */
-typedef struct battle_item{
-    int id; // the id of the item, should be unique for each individual type of item.
-    char *name; // the name of the item
-    char *description; // the description of the item
-    stat_changes_t *attributes; // the stats that are changed by the item
-    int quantity; // the amount of items we have of this item
-    bool attack; // determines whether the item is used as an attack against the enemy, or as a defensive item for player
-    struct battle_item *next; // the next battle item
-    struct battle_item *prev; // the previous battle item
-} battle_item_t;
-
 /* This defines what type of damage if any the move would do. 
     We will do this to specify attack. */
 typedef enum damage_type {
@@ -90,6 +62,34 @@ typedef struct move_t {
     struct move_t* prev; //the previous move in the list, or NULL for no move
     struct move_t* next; //the next move in the list, or NULL for no move
 } move_t;
+
+/* Defines the type of equipment a piece of equipment is */
+enum equipment_type{
+    ACCESSORY,
+    ARMOR,
+    WEAPON
+};
+
+/* A data structure of a piece of equipment */ 
+typedef struct battle_equipment{
+    int id; // the id of the equipment, should be unique for each individual type of equipment.
+    char *name; // the name of the equipment
+    char *description; // the description of the equipment
+    stat_changes_t *attributes; // the stats that are changed by the equipment
+    equipment_type type; // determines the type of equipment (armor, weapon, accessory)
+} battle_equipment_t;
+
+/* This defines battle items */
+typedef struct battle_item{
+    int id; // the id of the item, should be unique for each individual type of item.
+    char *name; // the name of the item
+    char *description; // the description of the item
+    stat_changes_t *attributes; // the stats that are changed by the item
+    int quantity; // the amount of items we have of this item
+    bool attack; // determines whether the item is used as an attack against the enemy, or as a defensive item for player
+    struct battle_item *next; // the next battle item
+    struct battle_item *prev; // the previous battle item
+} battle_item_t;
 
 /* stats stub */
 typedef struct stat {

--- a/include/battle/battle_structs.h
+++ b/include/battle/battle_structs.h
@@ -6,6 +6,52 @@
 #include "playerclass/class_structs.h"
 #include "playerclass/class.h"
 
+/* stat changes stub */
+typedef struct stat_changes {
+    int speed; //the amount speed changes from a stat change
+    int max_sp; //the amount max_sp changes from a stat change
+    int sp; //the amount sp changes from a stat change
+    int phys_atk; //the amount phys_atk changes from a stat change
+    int mag_atk; //the amount mag_atk changes from a stat change
+    int phys_def; //the amount phys_def changes from a stat change
+    int mag_def; //the amount mag_def changes from a stat change
+    int crit; //the amount crit changes from a stat change
+    int accuracy; //the amount accuracy changes from a stat change
+    int hp; //the amount hp changes from a stat change
+    int max_hp; //the amount max_hp changes from a stat change
+    int turns_left; //specifies the turns left of the stat changes
+    struct stat_changes* next; //the next stat_changes in the list, or NULL for no stat_change
+    struct stat_changes* prev; //the previous stat_changes in the list, or NULL for no stat_change
+} stat_changes_t;
+
+/* Defines the type of equipment a piece of equipment is */
+typedef enum equipment_type{
+    ACCESSORY,
+    ARMOR,
+    WEAPON
+} equipment_type_t;
+
+/* A data structure of a piece of equipment */ 
+typedef struct battle_equipment{
+    int id; // the id of the equipment, should be unique for each individual type of equipment.
+    char *name; // the name of the equipment
+    char *description; // the description of the equipment
+    stat_changes_t *attributes; // the stats that are changed by the equipment
+    equipment_type_t type; // determines the type of equipment (armor, weapon, accessory)
+} battle_equipment_t;
+
+/* This defines battle items */
+typedef struct battle_item{
+    int id; // the id of the item, should be unique for each individual type of item.
+    char *name; // the name of the item
+    char *description; // the description of the item
+    stat_changes_t *attributes; // the stats that are changed by the item
+    int quantity; // the amount of items we have of this item
+    bool attack; // determines whether the item is used as an attack against the enemy, or as a defensive item for player
+    struct battle_item *next; // the next battle item
+    struct battle_item *prev; // the previous battle item
+} battle_item_t;
+
 /* This defines what type of damage if any the move would do. 
     We will do this to specify attack. */
 typedef enum damage_type {
@@ -26,24 +72,6 @@ typedef enum target_count {
     MULTI //A move that hits multiple targets
 } target_count_t;
 
-/* stat changes stub */
-typedef struct stat_changes {
-    int speed; //the amount speed changes from a stat change
-    int max_sp; //the amount max_sp changes from a stat change
-    int sp; //the amount sp changes from a stat change
-    int phys_atk; //the amount phys_atk changes from a stat change
-    int mag_atk; //the amount mag_atk changes from a stat change
-    int phys_def; //the amount phys_def changes from a stat change
-    int mag_def; //the amount mag_def changes from a stat change
-    int crit; //the amount crit changes from a stat change
-    int accuracy; //the amount accuracy changes from a stat change
-    int hp; //the amount hp changes from a stat change
-    int max_hp; //the amount max_hp changes from a stat change
-    int turns_left; //specifies the turns left of the stat changes
-    struct stat_changes* next; //the next stat_changes in the list, or NULL for no stat_change
-    struct stat_changes* prev; //the previous stat_changes in the list, or NULL for no stat_change
-} stat_changes_t;
-
 /* moves stub */
 typedef struct move_t {
     int id; //the unique identifier of the move
@@ -62,34 +90,6 @@ typedef struct move_t {
     struct move_t* prev; //the previous move in the list, or NULL for no move
     struct move_t* next; //the next move in the list, or NULL for no move
 } move_t;
-
-/* Defines the type of equipment a piece of equipment is */
-enum equipment_type{
-    ACCESSORY,
-    ARMOR,
-    WEAPON
-};
-
-/* A data structure of a piece of equipment */ 
-typedef struct battle_equipment{
-    int id; // the id of the equipment, should be unique for each individual type of equipment.
-    char *name; // the name of the equipment
-    char *description; // the description of the equipment
-    stat_changes_t *attributes; // the stats that are changed by the equipment
-    equipment_type type; // determines the type of equipment (armor, weapon, accessory)
-} battle_equipment_t;
-
-/* This defines battle items */
-typedef struct battle_item{
-    int id; // the id of the item, should be unique for each individual type of item.
-    char *name; // the name of the item
-    char *description; // the description of the item
-    stat_changes_t *attributes; // the stats that are changed by the item
-    int quantity; // the amount of items we have of this item
-    bool attack; // determines whether the item is used as an attack against the enemy, or as a defensive item for player
-    struct battle_item *next; // the next battle item
-    struct battle_item *prev; // the previous battle item
-} battle_item_t;
 
 /* stats stub */
 typedef struct stat {

--- a/include/battle/battle_structs.h
+++ b/include/battle/battle_structs.h
@@ -6,22 +6,32 @@
 #include "playerclass/class_structs.h"
 #include "playerclass/class.h"
 
+/* Defines the type of equipment a piece of equipment is */
+enum equipment_type{
+    ACCESSORY,
+    ARMOR,
+    WEAPON
+};
 
-/* battle_items stub */
-typedef struct battle_item {
-    int id;
-    bool is_weapon;
-    int effectiveness_decrement;
-    int quantity;
-    int durability;
-    char* name;
-    char* description;
-    bool battle;
-    int attack;
-    int defense;
-    int hp;
-    struct battle_item *next;
-    struct battle_item *prev;
+/* A data structure of a piece of equipment */ 
+typedef struct battle_equipment{
+    int id; // the id of the equipment, should be unique for each individual type of equipment.
+    char *name; // the name of the equipment
+    char *description; // the description of the equipment
+    stat_changes_t *attributes; // the stats that are changed by the equipment
+    equipment_type type; // determines the type of equipment (armor, weapon, accessory)
+} battle_equipment_t;
+
+/* This defines battle items */
+typedef struct battle_item{
+    int id; // the id of the item, should be unique for each individual type of item.
+    char *name; // the name of the item
+    char *description; // the description of the item
+    stat_changes_t *attributes; // the stats that are changed by the item
+    int quantity; // the amount of items we have of this item
+    bool attack; // determines whether the item is used as an attack against the enemy, or as a defensive item for player
+    struct battle_item *next; // the next battle item
+    struct battle_item *prev; // the previous battle item
 } battle_item_t;
 
 /* This defines what type of damage if any the move would do. 

--- a/include/npc/npc.h
+++ b/include/npc/npc.h
@@ -278,7 +278,8 @@ int add_convo_to_npc(npc_t *npc, convo_t *c);
 int add_battle_to_npc(npc_t *npc, int health, stat_t *stats, move_t *moves,
                       difficulty_t ai, hostility_t hostility_level,
                       int surrender_level, class_t *class_type,
-                      battle_item_t *items);
+                      battle_item_t *items, battle_equipment_t *armor,
+                      battle_equipment_t *accessory, battle_equipment_t *weapon);
 
 /*
  * Changes the health of the npc.

--- a/include/npc/npc.h
+++ b/include/npc/npc.h
@@ -271,7 +271,9 @@ int add_convo_to_npc(npc_t *npc, convo_t *c);
  *  class_type: a pointer to an existing class_t struct defining the npc's class
            (see /include/playerclass/class_structs.h)
  *  items: An inventory of items that can be used in battle
- *
+ *  armor: a pointer to the armor an npc has
+ *  accessory: a pointer to the accessory an npc has
+ *  weapon: a pointer to the weapon an npc has
  * Returns:
  *  SUCCESS if successful, FAILURE if an error occurred.
  */

--- a/include/npc/npc_battle.h
+++ b/include/npc/npc_battle.h
@@ -39,6 +39,15 @@ typedef struct npc_battle {
 
     /* An inventory of items that can be used in battle */
     battle_item_t *items;
+
+    /* armor that an npc can equip*/ 
+    battle_equipment_t *armor;
+
+    /* an accessory that an npc can equip*/ 
+    battle_equipment_t *accessory;
+
+    /* weapon that an npc can equip*/ 
+    battle_equipment_t *weapon;
 } npc_battle_t;
 
 // STRUCT FUNCTIONS -----------------------------------------------------------

--- a/include/npc/npc_battle.h
+++ b/include/npc/npc_battle.h
@@ -67,6 +67,9 @@ typedef struct npc_battle {
  *  surrender_level: the level of health at which the npc surrenders the battle
  *  class_type: the class struct of the npc
  *  items: a doubly linked list of items that the npc can use during battle
+ * - weapon: the weapon equiped to the npc during battle
+ * - accessory: the accessory equiped to the npc during battle
+ * - armor: the armor equiped to the npc during battle
  *
  * Returns:
  *  SUCCESS on success, FAILURE if an error occurs
@@ -90,6 +93,9 @@ int npc_battle_init(npc_battle_t *npc_battle, int health, stat_t* stats,
  *  surrender_level: the level of health at which the npc surrenders the battle
  *  class_type: the class struct of the npc
  *  items: a doubly linked list of items that the npc can use during battle
+ * - weapon: the weapon equiped to the npc during battle
+ * - accessory: the accessory equiped to the npc during battle
+ * - armor: the armor equiped to the npc during battle
  *
  * Returns:
  *  pointer to allocated npc_battle

--- a/include/npc/npc_battle.h
+++ b/include/npc/npc_battle.h
@@ -74,7 +74,8 @@ typedef struct npc_battle {
 int npc_battle_init(npc_battle_t *npc_battle, int health, stat_t* stats, 
                     move_t* moves, difficulty_t ai, hostility_t hostility_level,
                     int surrender_level, class_t *class_type, 
-                    battle_item_t *items);
+                    battle_item_t *items, battle_equipment_t *armor,
+                    battle_equipment_t *accessory, battle_equipment_t *weapon);
 /*
  * Allocates a new npc_battle struct in the heap.
  *
@@ -96,7 +97,9 @@ int npc_battle_init(npc_battle_t *npc_battle, int health, stat_t* stats,
 npc_battle_t *npc_battle_new(int health, stat_t* stats, move_t* moves, 
 		                    difficulty_t ai, hostility_t hostility_level, 
 			                int surrender_level, class_t *class_type,
-                            battle_item_t *items);
+                            battle_item_t *items, battle_equipment_t *armor,
+                            battle_equipment_t *accessory,
+                            battle_equipment_t *weapon);
 
 /*
  * Frees resources associated with an npc_battle struct.

--- a/src/battle/examples/battle_cli_example.c
+++ b/src/battle/examples/battle_cli_example.c
@@ -75,9 +75,11 @@ char *fight_operation(char *tokens[TOKEN_LIST_SIZE], chiventure_ctx_t *ctx)
     move_t *e_move = get_random_default_move();
     npc_t *e = npc_new("Goblin", "Enemy goblin!", "Enemy goblin!", make_bard2(), NULL, true);
     npc_battle_t *npc_b = npc_battle_new(100, e_stats, e_move, 
-                                        BATTLE_AI_GREEDY, HOSTILE, 0, NULL, NULL);
+                                        BATTLE_AI_GREEDY, HOSTILE, 0, NULL, NULL,
+                                        NULL, NULL, NULL);
     e->npc_battle = npc_b;
-    battle_player_t *p = new_ctx_player("John", make_wizard2(), p_stats, p_move, p_item);
+    battle_player_t *p = new_ctx_player("John", make_wizard2(), p_stats, p_move, p_item,
+                                        NULL, NULL, NULL);
 
     battle_ctx_t *battle_ctx =
         (battle_ctx_t *)calloc(1, sizeof(battle_ctx_t));

--- a/src/battle/src/battle_default_objects.c
+++ b/src/battle/src/battle_default_objects.c
@@ -240,12 +240,21 @@ battle_item_t *get_random_default_consumable()
     strncpy(rv_item->description, description_array[rand - 1], description_len + 1);
 
     rv_item->attributes = stat_changes_new();
-    if (rand < 2) {
-        rv_item->attributes->hp = mod_array[rand];
-    } else if (rand == 2) {
-        rv_item->attributes->phys_atk = mod_array[rand];
-    } else {
-        rv_item->attributes->phys_def = mod_array[rand];
+    if(rand == 1) 
+    {
+        rv_item->attributes->hp = mod_array[rand-1];
+    }
+    else if (rand == 2)
+    {
+        rv_item->attributes->hp = mod_array[rand-1];
+    } 
+    else if (rand == 3) 
+    {
+        rv_item->attributes->phys_atk = mod_array[rand-1];
+    } 
+    else 
+    {
+        rv_item->attributes->phys_def = mod_array[rand-1];
     }
 
     rv_item->quantity = randnum(1, 3);

--- a/src/battle/src/battle_default_objects.c
+++ b/src/battle/src/battle_default_objects.c
@@ -17,7 +17,7 @@ int randnum(int min, int max)
 }
 
 /* See battle_default_objects.h */
-battle_item_t *get_random_offensive item()
+battle_item_t *get_random_offensive_item()
 {
     battle_item_t *rv_offitem = calloc(1, sizeof(battle_item_t));
     assert(rv_offitem != NULL);
@@ -75,7 +75,7 @@ battle_item_t *get_random_offensive item()
 
 battle_equipment_t *get_random_equip_weapon()
 {
-    battle_item_t *rv_weapon = calloc(1, sizeof(battle_equipment_t));
+    battle_equipment_t *rv_weapon = calloc(1, sizeof(battle_equipment_t));
     assert(rv_weapon != NULL);
 
     int rand = (randnum(1, 4)) - 1; 

--- a/src/battle/src/battle_default_objects.c
+++ b/src/battle/src/battle_default_objects.c
@@ -220,14 +220,14 @@ battle_item_t *get_random_default_consumable()
     assert(rv_item != NULL);
 
     int rand = randnum(1, 4); 
-    char* name_array[]= {"elixir of life ", "healing potion ", 
-                         "defense up ", "strength up "};
+    char* name_array[]= {"Elixir of Life", "Healing Potion", 
+                         "Defense Up", "Strength Up"};
     char* description_array[] = {"Adds 50 to your HP!", "Adds 20 to your HP!", 
-                                 "Adds 5 to your defense!", 
-                                 "Adds 5 to your strength!"};
+                                 "Adds 5 to your Physical Defense!", 
+                                 "Adds 5 to your Physical Attack!"};
     int mod_array[] = {50, 20, 5, 5};
 
-    rv_item->id = rand ;
+    rv_item->id = rand;
 
     // sets name
     int name_len = strlen(name_array[rand - 1]);
@@ -240,21 +240,19 @@ battle_item_t *get_random_default_consumable()
     strncpy(rv_item->description, description_array[rand - 1], description_len + 1);
 
     rv_item->attributes = stat_changes_new();
-    if(rand == 1) 
-    {
-        rv_item->attributes->hp = mod_array[rand-1];
-    }
-    else if (rand == 2)
-    {
-        rv_item->attributes->hp = mod_array[rand-1];
-    } 
-    else if (rand == 3) 
-    {
-        rv_item->attributes->phys_def = mod_array[rand-1];
-    } 
-    else 
-    {
-        rv_item->attributes->phys_atk = mod_array[rand-1];
+    switch(rand){
+
+        case 1:
+            rv_item->attributes->hp = mod_array[rand-1];
+            break;
+        case 2:
+            rv_item->attributes->hp = mod_array[rand-1];
+            break;
+        case 3:
+            rv_item->attributes->phys_def = mod_array[rand-1];
+            break;
+        default:
+            rv_item->attributes->phys_atk = mod_array[rand-1];
     }
 
     rv_item->quantity = randnum(1, 3);

--- a/src/battle/src/battle_default_objects.c
+++ b/src/battle/src/battle_default_objects.c
@@ -219,7 +219,7 @@ battle_item_t *get_random_default_consumable()
     battle_item_t *rv_item = calloc(1, sizeof(battle_item_t));
     assert(rv_item != NULL);
 
-    int rand = randnum(1, 4) - 1; 
+    int rand = randnum(1, 4); 
     char* name_array[]= {"elixir of life ", "healing potion ", 
                          "defense up ", "strength up "};
     char* description_array[] = {"Adds 50 to your HP!", "Adds 20 to your HP!", 

--- a/src/battle/src/battle_default_objects.c
+++ b/src/battle/src/battle_default_objects.c
@@ -227,7 +227,7 @@ battle_item_t *get_random_default_consumable()
                                  "Adds 5 to your strength!"};
     int mod_array[] = {50, 20, 5, 5};
 
-    rv_item->id = rand + 1;
+    rv_item->id = rand ;
 
     // sets name
     int name_len = strlen(name_array[rand - 1]);

--- a/src/battle/src/battle_default_objects.c
+++ b/src/battle/src/battle_default_objects.c
@@ -250,11 +250,11 @@ battle_item_t *get_random_default_consumable()
     } 
     else if (rand == 3) 
     {
-        rv_item->attributes->phys_atk = mod_array[rand-1];
+        rv_item->attributes->phys_def = mod_array[rand-1];
     } 
     else 
     {
-        rv_item->attributes->phys_def = mod_array[rand-1];
+        rv_item->attributes->phys_atk = mod_array[rand-1];
     }
 
     rv_item->quantity = randnum(1, 3);

--- a/src/battle/src/battle_default_objects.c
+++ b/src/battle/src/battle_default_objects.c
@@ -32,6 +32,8 @@ battle_item_t *get_random_offensive_item()
                                  "Reduces enemy's DEFENSE by 10", 
                                  "Reduces enemy's DEFENSE by 15"};
 
+    int mod_array[] = {-20, -10, -5, -10, -10, -15};
+
     rv_offitem->id = rand + 1;
     
     /* sets name */

--- a/src/battle/src/battle_default_objects.c
+++ b/src/battle/src/battle_default_objects.c
@@ -225,6 +225,7 @@ battle_item_t *get_random_default_consumable()
     char* description_array[] = {"Adds 50 to your HP!", "Adds 20 to your HP!", 
                                  "Adds 5 to your defense!", 
                                  "Adds 5 to your strength!"};
+    int mod_array[] = {50, 20, 5, 5};
 
     rv_item->id = rand + 1;
 

--- a/src/battle/src/battle_default_objects.c
+++ b/src/battle/src/battle_default_objects.c
@@ -17,46 +17,65 @@ int randnum(int min, int max)
 }
 
 /* See battle_default_objects.h */
-battle_item_t *get_random_default_weapon()
+battle_item_t *get_random_offensive item()
 {
-    battle_item_t *rv_weapon = calloc(1, sizeof(battle_item_t));
-    assert(rv_weapon != NULL);
+    battle_item_t *rv_offitem = calloc(1, sizeof(battle_item_t));
+    assert(rv_offitem != NULL);
 
-    int rand = randnum(1, 6); 
-    char* name_array[]= {"Sword", "Hammer", "Slime", "Sleeping gas", "Squid ink", "Laughing gas"};
-    char* description_array[] = {"Reduces enemy's HP by 20", "Reduces enemy's HP by 10", 
-                                 "Reduces enemy's ATTACK by 5", "Reduces enemy's ATTACK by 10",
-                                 "Reduces enemy's DEFENSE by 10", "Reduces enemy's DEFENSE by 15"};
-    int hp_array[] = {-20, -10, 0, 0, 0, 0};
-    int attack_array[] = {0, 0, -5, -10, 0, 0};
-    int defense_array[] = {0, 0, 0, 0, -10, -15};
-    int durability_array[] = {100, 80, 60, 40, 30, 20};
+    int rand = randnum(1, 6) - 1; 
+    char* name_array[]= {"Sword", "Hammer", "Slime", "Sleeping gas", 
+                         "Squid ink", "Laughing gas"};
+    char* description_array[] = {"Reduces enemy's HP by 20", 
+                                 "Reduces enemy's HP by 10", 
+                                 "Reduces enemy's ATTACK by 5", 
+                                 "Reduces enemy's ATTACK by 10",
+                                 "Reduces enemy's DEFENSE by 10", 
+                                 "Reduces enemy's DEFENSE by 15"};
 
-    rv_weapon->id = rand;
-    rv_weapon->is_weapon = true;
-    rv_weapon->effectiveness_decrement = 10;
-    rv_weapon->quantity = randnum(1, 3);
-    rv_weapon->durability = durability_array[rand - 1]; 
-
+    rv_offitem->id = rand + 1;
+    
     /* sets name */
-    int name_len = strlen(name_array[rand - 1]);
-    rv_weapon->name = (char*)calloc(name_len + 1, sizeof(char));
-    strncpy(rv_weapon->name, name_array[rand - 1], name_len + 1);
-    /* sets description */
-    int description_len = strlen(description_array[rand - 1]);
-    rv_weapon->description = (char*)calloc(description_len + 1, sizeof(char));
-    strncpy(rv_weapon->description, description_array[rand - 1], description_len + 1);
-                                     
-    rv_weapon->battle = true;
-    rv_weapon->attack = attack_array[rand - 1];
-    rv_weapon->defense = defense_array[rand - 1];
-    rv_weapon->hp = hp_array[rand - 1];
-    rv_weapon->next = NULL;
-    rv_weapon->prev = NULL;
-    return rv_weapon;
+    int name_len = strlen(name_array[rand]);
+    rv_offitem->name = (char*)calloc(name_len + 1, sizeof(char));
+    strncpy(rv_offitem->name, name_array[rand], name_len + 1);
 
-/*  --BATTLE ITEM TEST CHANGES TO BE IMPLEMENTED WITH BATTLE ITEM CHANGES
-    battle_item_t *rv_weapon = calloc(1, sizeof(battle_item_t));
+    /* sets description */
+    int description_len = strlen(description_array[rand]);
+    rv_offitem->description = (char*)calloc(description_len + 1, sizeof(char));
+    strncpy(rv_offitem->description, description_array[rand], description_len + 1);
+
+    rv_offitem->attributes = stat_changes_new();
+    switch (rand) {
+        case 0:
+            rv_offitem->attributes->hp = mod_array[rand];
+            break;
+        case 1:
+            rv_offitem->attributes->hp = mod_array[rand];
+            break;
+        case 2:
+            rv_offitem->attributes->phys_atk = mod_array[rand];
+            break;
+        case 3:
+            rv_offitem->attributes->phys_atk = mod_array[rand];
+            break;
+        case 4:
+            rv_offitem->attributes->phys_def = mod_array[rand];
+            break;
+        default:
+            rv_offitem->attributes->phys_def = mod_array[rand]; 
+    }
+    
+    rv_offitem->quantity = randnum(1, 3);
+    rv_offitem->attack = true;
+
+    rv_offitem->next = NULL;
+    rv_offitem->prev = NULL;
+    return rv_offitem;
+}
+
+battle_equipment_t *get_random_equip_weapon()
+{
+    battle_item_t *rv_weapon = calloc(1, sizeof(battle_equipment_t));
     assert(rv_weapon != NULL);
 
     int rand = (randnum(1, 4)) - 1; 
@@ -66,40 +85,131 @@ battle_item_t *get_random_default_weapon()
                                  "Adds 15 to Speed", "Adds 15 to Magical Attack"};
     int mod_array[] = {25, 15, 15, 15};
 
-    rv_weapon->id = rand;
-    rv_weapon->is_weapon = true;
-    rv_weapon->effectiveness_decrement = 10;
-    rv_weapon->quantity = 1;
-    rv_weapon->durability = 1; 
+    rv_weapon->id = rand + 1; 
 
     // sets name
     int name_len = strlen(name_array[rand]);
     rv_weapon->name = (char*)calloc(name_len + 1, sizeof(char));
     strncpy(rv_weapon->name, name_array[rand], name_len + 1);
+
     // sets description
     int description_len = strlen(description_array[rand]);
     rv_weapon->description = (char*)calloc(description_len + 1, sizeof(char));
     strncpy(rv_weapon->description, description_array[rand], description_len + 1);
     
-    rv_weapon->battle = true;
-//
-    if (rand == 0) {
-        rv_item->hp = mod_array[rand];
-    } else if (rand == 1) {
-        rv_item->phys_atk = mod_array[rand];
-    } else if (rand == 2) {
-        rv_item->speed = mod_array[rand];
-    } else if (rand == 3) {
-        rv_item->mag_atk = mod_array[rand];
+    rv_weapon->attributes = stat_changes_new();
+    switch (rand) {
+        case 0:
+            rv_weapon->attributes->hp = mod_array[rand];
+            break;
+        case 1:
+            rv_weapon->attributes->phys_atk = mod_array[rand];
+            break;
+        case 2:
+            rv_weapon->attributes->speed = mod_array[rand];
+            break;
+        default:
+            rv_weapon->attributes->mag_atk = mod_array[rand];
     }
-//
 
-    rv_weapon->next = NULL;
-    rv_weapon->prev = NULL;
+    rv_weapon->type = WEAPON;
 
     return rv_weapon;
-*/
 }
+
+battle_equipment_t *get_random_equip_armor()
+{
+    battle_item_t *rv_armor = calloc(1, sizeof(battle_equipment_t));
+    assert(rv_armor != NULL);
+
+    int rand = (randnum(1, 4)) - 1; 
+    char* name_array[]= {"Simple Leather Armor", "Chainmail", 
+                         "Heavy Armor", "Loincloth"};
+    char* description_array[] = {"Adds 10 to Physical Defense.", 
+                                 "Adds 15 to Physical Defense.",
+                                 "Adds 25 to Physical Defense.", 
+                                 "Adds 15 to Magical Defense."};
+    int mod_array[] = {10, 15, 25, 15};
+
+    rv_armor->id = rand + 1; 
+
+    // sets name
+    int name_len = strlen(name_array[rand]);
+    rv_armor->name = (char*)calloc(name_len + 1, sizeof(char));
+    strncpy(rv_armor->name, name_array[rand], name_len + 1);
+
+    // sets description
+    int description_len = strlen(description_array[rand]);
+    rv_armor->description = (char*)calloc(description_len + 1, sizeof(char));
+    strncpy(rv_armor->description, description_array[rand], description_len + 1);
+    
+    rv_armor->attributes = stat_changes_new();
+    switch (rand) {
+        case 0:
+            rv_armor->attributes->phys_def = mod_array[rand];
+            break;
+        case 1:
+            rv_armor->attributes->phys_def = mod_array[rand];
+            break;
+        case 2:
+            rv_armor->attributes->phys_def = mod_array[rand];
+            break;
+        default:
+            rv_armor->attributes->mag_def = mod_array[rand];
+    }
+
+    rv_armor->type = ARMOR;
+
+    return rv_armor;
+}
+
+battle_equipment_t *get_random_equip_accessory()
+{
+    battle_item_t *rv_access = calloc(1, sizeof(battle_equipment_t));
+    assert(rv_access != NULL);
+
+    int rand = (randnum(1, 4)) - 1; 
+    char* name_array[]= {"Heart-Shaped Pendant", "Faded Ribbon", 
+                         "Winged Boots", "Sword Charm"};
+    char* description_array[] = {"Adds 20 to HP.", 
+                                 "Adds 10 to Physical Defense.",
+                                 "Adds 15 to Speed.", 
+                                 "Adds 10 to Magical Defense."};
+    int mod_array[] = {20, 10, 15, 10};
+
+    rv_access->id = rand + 1; 
+
+    // sets name
+    int name_len = strlen(name_array[rand]);
+    rv_access->name = (char*)calloc(name_len + 1, sizeof(char));
+    strncpy(rv_access->name, name_array[rand], name_len + 1);
+
+    // sets description
+    int description_len = strlen(description_array[rand]);
+    rv_access->description = (char*)calloc(description_len + 1, sizeof(char));
+    strncpy(rv_access->description, description_array[rand], description_len + 1);
+    
+    rv_access->attributes = stat_changes_new();
+    switch (rand) {
+        case 0:
+            rv_access->attributes->hp = mod_array[rand];
+            break;
+        case 1:
+            rv_access->attributes->phys_def = mod_array[rand];
+            break;
+        case 2:
+            rv_access->attributes->speed = mod_array[rand];
+            break;
+        default:
+            rv_access->attributes->mag_def = mod_array[rand];
+    }
+
+    rv_access->type = ACCESSORY;
+
+    return rv_access;
+}
+
+
 
 /* See battle_default_objects.h */
 battle_item_t *get_random_default_consumable()
@@ -107,82 +217,41 @@ battle_item_t *get_random_default_consumable()
     battle_item_t *rv_item = calloc(1, sizeof(battle_item_t));
     assert(rv_item != NULL);
 
-    int rand = randnum(1, 4); 
-    char* name_array[]= {"elixir of life ", "healing potion ", "defense up ", "strength up "};
+    int rand = randnum(1, 4) - 1; 
+    char* name_array[]= {"elixir of life ", "healing potion ", 
+                         "defense up ", "strength up "};
     char* description_array[] = {"Adds 50 to your HP!", "Adds 20 to your HP!", 
-                                 "Adds 5 to your defense!", "Adds 5 to your strength!"};
-    int hp_array[] = {50, 20, 0, 0};
-    int attack_array[] = {0, 0, 0, 5};
-    int defense_array[] = {0, 0, 5, 0};
+                                 "Adds 5 to your defense!", 
+                                 "Adds 5 to your strength!"};
 
-    rv_item->id = rand;
-    rv_item->is_weapon = false;
-    rv_item->quantity = randnum(1, 3);
-    rv_item->durability = 0; 
+    rv_item->id = rand + 1;
 
     // sets name
     int name_len = strlen(name_array[rand - 1]);
     rv_item->name = (char*)calloc(name_len + 1, sizeof(char));
     strncpy(rv_item->name, name_array[rand - 1], name_len + 1);
+
     // sets description
     int description_len = strlen(description_array[rand - 1]);
     rv_item->description = (char*)calloc(description_len + 1, sizeof(char));
     strncpy(rv_item->description, description_array[rand - 1], description_len + 1);
-                                     
-    rv_item->battle = true;
-    rv_item->attack = attack_array[rand - 1];
-    rv_item->defense = defense_array[rand - 1];
-    rv_item->hp = hp_array[rand - 1];
-    rv_item->next = NULL;
-    rv_item->prev = NULL;
-    return rv_item;
-/*  --BATTLE ITEM TEST CHANGES TO BE IMPLEMENTED WITH BATTLE ITEM CHANGES
-    battle_item_t *rv_item = calloc(1, sizeof(battle_item_t));
-    assert(rv_item != NULL);
 
-    int rand = (randnum(1, 5)) - 1; 
-    char* name_array[]= {"Elixir of Life", "Healing Potion", 
-                         "Physical Attack-Up", " Physical Defense-Up", 
-                         "Speed-Up"};
-    char* description_array[] = {"Adds 50 to your HP!", "Adds 20 to your HP!", 
-                                 "Adds 10 to your physical defense!", 
-                                 "Adds 10 to your physical attack!", 
-                                 "Adds 10 to your speed!"};
-    int mod_array[] = {50, 20, 10, 10, 10}; 
-
-    rv_item->id = rand;
-    rv_item->is_weapon = false;
-    rv_item->quantity = randnum(1, 3);
-    rv_item->durability = 0; 
-
-    // sets name
-    int name_len = strlen(name_array[rand]);
-    rv_item->name = (char*)calloc(name_len + 1, sizeof(char));
-    strncpy(rv_item->name, name_array[rand], name_len + 1);
-    // sets description
-    int description_len = strlen(description_array[rand]);
-    rv_item->description = (char*)calloc(description_len + 1, sizeof(char));
-    strncpy(rv_item->description, description_array[rand], description_len + 1);
-    
-    rv_item->battle = true;
-
-//
+    rv_item->attributes = stat_changes_new();
     if (rand < 2) {
-        rv_item->hp = mod_array[rand];
+        rv_item->attributes->hp = mod_array[rand];
     } else if (rand == 2) {
-        rv_item->phys_atk = mod_array[rand];
-    } else if (rand == 3) {
-        rv_item->phys_def = mod_array[rand];
-    } else if (rand == 4) {
-        rv_item->speed = mod_array[rand];
+        rv_item->attributes->phys_atk = mod_array[rand];
+    } else {
+        rv_item->attributes->phys_def = mod_array[rand];
     }
-//
+
+    rv_item->quantity = randnum(1, 3);
+    rv_item->attack = false;
 
     rv_item->next = NULL;
     rv_item->prev = NULL;
 
     return rv_item;
-*/
 }
 
 /* See battle_default_objects.h */

--- a/src/battle/src/battle_default_objects.c
+++ b/src/battle/src/battle_default_objects.c
@@ -119,7 +119,7 @@ battle_equipment_t *get_random_equip_weapon()
 
 battle_equipment_t *get_random_equip_armor()
 {
-    battle_item_t *rv_armor = calloc(1, sizeof(battle_equipment_t));
+    battle_equipment_t *rv_armor = calloc(1, sizeof(battle_equipment_t));
     assert(rv_armor != NULL);
 
     int rand = (randnum(1, 4)) - 1; 
@@ -165,7 +165,7 @@ battle_equipment_t *get_random_equip_armor()
 
 battle_equipment_t *get_random_equip_accessory()
 {
-    battle_item_t *rv_access = calloc(1, sizeof(battle_equipment_t));
+    battle_equipment_t *rv_access = calloc(1, sizeof(battle_equipment_t));
     assert(rv_access != NULL);
 
     int rand = (randnum(1, 4)) - 1; 

--- a/src/battle/src/battle_flow.c
+++ b/src/battle/src/battle_flow.c
@@ -28,10 +28,14 @@ combatant_t *set_battle_player(battle_player_t *ctx_player)
     stat_t *stats = ctx_player->stats;
     move_t *moves = ctx_player->moves;
     battle_item_t *items = ctx_player->items;
+    battle_equipment_t *weapon = ctx_player->weapon; 
+    battle_equipment_t *accessory ctx_player->accessory; 
+    battle_equipment_t *armor = ctx_player->armor;
 
     // Allocating new combatant_t for the player in memory
     combatant_t *comb_player = combatant_new(name, is_friendly, c_type, stats,
-                                             moves, items, BATTLE_AI_NONE);
+                                             moves, items, weapon, accessory,
+                                             armer, BATTLE_AI_NONE);
 
     assert(comb_player != NULL);
 

--- a/src/battle/src/battle_flow.c
+++ b/src/battle/src/battle_flow.c
@@ -29,7 +29,7 @@ combatant_t *set_battle_player(battle_player_t *ctx_player)
     move_t *moves = ctx_player->moves;
     battle_item_t *items = ctx_player->items;
     battle_equipment_t *weapon = ctx_player->weapon; 
-    battle_equipment_t *accessory ctx_player->accessory; 
+    battle_equipment_t *accessory = ctx_player->accessory; 
     battle_equipment_t *armor = ctx_player->armor;
     stat_t *with_equipment = (stat_t *) calloc (1, sizeof(stat_t *));
     with_equipment = stats;
@@ -75,7 +75,7 @@ combatant_t *set_battle_player(battle_player_t *ctx_player)
     // Allocating new combatant_t for the player in memory
     combatant_t *comb_player = combatant_new(name, is_friendly, c_type, with_equipment,
                                              moves, items, weapon, accessory,
-                                             armer, BATTLE_AI_NONE);
+                                             armor, BATTLE_AI_NONE);
 
     assert(comb_player != NULL);
 
@@ -99,9 +99,9 @@ combatant_t *set_enemy(npc_t *npc_enemy)
     move_t *moves = npc_enemy->npc_battle->moves;
     battle_item_t *items = NULL; // TODO: extract battle_item_t from npc's inventory
     difficulty_t ai = npc_enemy->npc_battle->ai;
-    battle_equipment_t *weapon = ctx_player->weapon; 
-    battle_equipment_t *accessory ctx_player->accessory; 
-    battle_equipment_t *armor = ctx_player->armor;
+    battle_equipment_t *weapon = npc_enemy->weapon; 
+    battle_equipment_t *accessory npc_enemy->accessory; 
+    battle_equipment_t *armor = npc_enemy->armor;
     // we will need to update npc_battle_t after npc is done with their merge
     stat_t *with_equipment = (stat_t *) calloc (1, sizeof(stat_t *));
     with_equipment = stats;

--- a/src/battle/src/battle_flow.c
+++ b/src/battle/src/battle_flow.c
@@ -100,7 +100,7 @@ combatant_t *set_enemy(npc_t *npc_enemy)
     battle_item_t *items = NULL; // TODO: extract battle_item_t from npc's inventory
     difficulty_t ai = npc_enemy->npc_battle->ai;
     battle_equipment_t *weapon = npc_enemy->weapon; 
-    battle_equipment_t *accessory npc_enemy->accessory; 
+    battle_equipment_t *accessory = npc_enemy->accessory; 
     battle_equipment_t *armor = npc_enemy->armor;
     // we will need to update npc_battle_t after npc is done with their merge
     stat_t *with_equipment = (stat_t *) calloc (1, sizeof(stat_t *));

--- a/src/battle/src/battle_flow.c
+++ b/src/battle/src/battle_flow.c
@@ -99,9 +99,9 @@ combatant_t *set_enemy(npc_t *npc_enemy)
     move_t *moves = npc_enemy->npc_battle->moves;
     battle_item_t *items = NULL; // TODO: extract battle_item_t from npc's inventory
     difficulty_t ai = npc_enemy->npc_battle->ai;
-    battle_equipment_t *weapon = npc_enemy->weapon; 
-    battle_equipment_t *accessory = npc_enemy->accessory; 
-    battle_equipment_t *armor = npc_enemy->armor;
+    battle_equipment_t *weapon = npc_enemy->npc_battle->weapon; 
+    battle_equipment_t *accessory = npc_enemy->npc_battle->accessory; 
+    battle_equipment_t *armor = npc_enemy->npc_battle->armor;
     // we will need to update npc_battle_t after npc is done with their merge
     stat_t *with_equipment = (stat_t *) calloc (1, sizeof(stat_t *));
     with_equipment = stats;

--- a/src/battle/src/battle_flow.c
+++ b/src/battle/src/battle_flow.c
@@ -31,9 +31,49 @@ combatant_t *set_battle_player(battle_player_t *ctx_player)
     battle_equipment_t *weapon = ctx_player->weapon; 
     battle_equipment_t *accessory ctx_player->accessory; 
     battle_equipment_t *armor = ctx_player->armor;
-
+    stat_t *with_equipment = (stat_t *) calloc (1, sizeof(stat_t *));
+    with_equipment = stats;
+    if (weapon != NULL)
+    {
+        with_equipment->max_sp+=weapon->attributes->max_sp;
+        with_equipment->sp+=weapon->attributes->sp;
+        with_equipment->phys_atk+=weapon->attributes->phys_atk;
+        with_equipment->mag_atk+=weapon->attributes->mag_atk;
+        with_equipment->phys_def+=weapon->attributes->phys_def;
+        with_equipment->mag_def+=weapon->attributes->mag_def;
+        with_equipment->crit+=weapon->attributes->crit;
+        with_equipment->accuracy+=weapon->attributes->accuracy;
+        with_equipment->hp+=weapon->attributes->hp;
+        with_equipment->max_hp+=weapon->attributes->max_hp;
+    }
+    if (accessory !=NULL)
+    {
+        with_equipment->max_sp+=accessory->attributes->max_sp;
+        with_equipment->sp+=accessory->attributes->sp;
+        with_equipment->phys_atk+=accessory->attributes->phys_atk;
+        with_equipment->mag_atk+=accessory->attributes->mag_atk;
+        with_equipment->phys_def+=accessory->attributes->phys_def;
+        with_equipment->mag_def+=accessory->attributes->mag_def;
+        with_equipment->crit+=accessory->attributes->crit;
+        with_equipment->accuracy+=accessory->attributes->accuracy;
+        with_equipment->hp+=accessory->attributes->hp;
+        with_equipment->max_hp+=accessory->attributes->max_hp;
+    }
+    if (armor != NULL)
+    {
+        with_equipment->max_sp+=armor->attributes->max_sp;
+        with_equipment->sp+=armor->attributes->sp;
+        with_equipment->phys_atk+=armor->attributes->phys_atk;
+        with_equipment->mag_atk+=armor->attributes->mag_atk;
+        with_equipment->phys_def+=armor->attributes->phys_def;
+        with_equipment->mag_def+=armor->attributes->mag_def;
+        with_equipment->crit+=armor->attributes->crit;
+        with_equipment->accuracy+=armor->attributes->accuracy;
+        with_equipment->hp+=armor->attributes->hp;
+        with_equipment->max_hp+=armor->attributes->max_hp;
+    }                                              
     // Allocating new combatant_t for the player in memory
-    combatant_t *comb_player = combatant_new(name, is_friendly, c_type, stats,
+    combatant_t *comb_player = combatant_new(name, is_friendly, c_type, with_equipment,
                                              moves, items, weapon, accessory,
                                              armer, BATTLE_AI_NONE);
 
@@ -59,8 +99,53 @@ combatant_t *set_enemy(npc_t *npc_enemy)
     move_t *moves = npc_enemy->npc_battle->moves;
     battle_item_t *items = NULL; // TODO: extract battle_item_t from npc's inventory
     difficulty_t ai = npc_enemy->npc_battle->ai;
-    
-    comb_enemy = combatant_new(name, is_friendly, c_type, stats, moves, items, ai);
+    battle_equipment_t *weapon = ctx_player->weapon; 
+    battle_equipment_t *accessory ctx_player->accessory; 
+    battle_equipment_t *armor = ctx_player->armor;
+    // we will need to update npc_battle_t after npc is done with their merge
+    stat_t *with_equipment = (stat_t *) calloc (1, sizeof(stat_t *));
+    with_equipment = stats;
+    if (weapon != NULL)
+    {
+        with_equipment->max_sp+=weapon->attributes->max_sp;
+        with_equipment->sp+=weapon->attributes->sp;
+        with_equipment->phys_atk+=weapon->attributes->phys_atk;
+        with_equipment->mag_atk+=weapon->attributes->mag_atk;
+        with_equipment->phys_def+=weapon->attributes->phys_def;
+        with_equipment->mag_def+=weapon->attributes->mag_def;
+        with_equipment->crit+=weapon->attributes->crit;
+        with_equipment->accuracy+=weapon->attributes->accuracy;
+        with_equipment->hp+=weapon->attributes->hp;
+        with_equipment->max_hp+=weapon->attributes->max_hp;
+    }
+    if (accessory !=NULL)
+    {
+        with_equipment->max_sp+=accessory->attributes->max_sp;
+        with_equipment->sp+=accessory->attributes->sp;
+        with_equipment->phys_atk+=accessory->attributes->phys_atk;
+        with_equipment->mag_atk+=accessory->attributes->mag_atk;
+        with_equipment->phys_def+=accessory->attributes->phys_def;
+        with_equipment->mag_def+=accessory->attributes->mag_def;
+        with_equipment->crit+=accessory->attributes->crit;
+        with_equipment->accuracy+=accessory->attributes->accuracy;
+        with_equipment->hp+=accessory->attributes->hp;
+        with_equipment->max_hp+=accessory->attributes->max_hp;
+    }
+    if (armor != NULL)
+    {
+        with_equipment->max_sp+=armor->attributes->max_sp;
+        with_equipment->sp+=armor->attributes->sp;
+        with_equipment->phys_atk+=armor->attributes->phys_atk;
+        with_equipment->mag_atk+=armor->attributes->mag_atk;
+        with_equipment->phys_def+=armor->attributes->phys_def;
+        with_equipment->mag_def+=armor->attributes->mag_def;
+        with_equipment->crit+=armor->attributes->crit;
+        with_equipment->accuracy+=armor->attributes->accuracy;
+        with_equipment->hp+=armor->attributes->hp;
+        with_equipment->max_hp+=armor->attributes->max_hp;
+    }
+    comb_enemy = combatant_new(name, is_friendly, c_type, with_equipment,
+                            moves, items, weapon, accessory, armor, ai);
     assert(comb_enemy != NULL);
 
     return comb_enemy;

--- a/src/battle/src/battle_flow.c
+++ b/src/battle/src/battle_flow.c
@@ -286,22 +286,6 @@ char *enemy_make_move(battle_ctx_t *ctx)
 
     return string;
 }
-/* see battle_flow.h */
-int apply_stat_changes(stat_t* target_stats, stat_changes_t* changes)  
-{
-    target_stats->speed += changes->speed;
-    target_stats->max_sp += changes->max_sp;
-    target_stats->sp += changes->sp;
-    target_stats->phys_atk += changes->phys_atk;
-    target_stats->mag_atk += changes->mag_atk;
-    target_stats->phys_def += changes->phys_def;
-    target_stats->mag_def += changes->mag_def;
-    target_stats->crit += changes->crit;
-    target_stats->accuracy += changes->accuracy;
-    target_stats->hp += changes->hp;
-    target_stats->max_hp += changes->max_hp;
-    return SUCCESS;
-}
 
 /* see battle_flow.h */
 int use_stat_change_move(combatant_t* target, move_t* move, combatant_t* source)

--- a/src/battle/src/battle_flow_structs.c
+++ b/src/battle/src/battle_flow_structs.c
@@ -6,7 +6,9 @@
 
 /* Stub for the player_new function in player.h game-state module */
 
-battle_player_t *new_ctx_player(char* p_id, class_t *c_type, stat_t *stats, move_t *moves, battle_item_t* items)
+battle_player_t *new_ctx_player(char* p_id, class_t *c_type, stat_t *stats, move_t *moves, 
+                              battle_item_t* items, battle_equipment_t *weapon, 
+                              battle_equipment_t *accessory, battle_equipment_t *armor)
 {
       battle_player_t *ctx_player = calloc(1, sizeof(battle_player_t));
       assert(ctx_player != NULL);
@@ -16,6 +18,9 @@ battle_player_t *new_ctx_player(char* p_id, class_t *c_type, stat_t *stats, move
       ctx_player->stats = stats;
       ctx_player->moves = moves;
       ctx_player->items = items;
+      ctx_player->weapon = weapon;
+      ctx_player->accessory = accessory;
+      ctx_player->armor = armor;
 
       return ctx_player;
 }

--- a/src/battle/src/battle_logic.c
+++ b/src/battle/src/battle_logic.c
@@ -204,15 +204,22 @@ int stat_changes_add_item_node(stat_changes_t *sc, battle_item_t *item)
         sc = sc->next;
     }
     stat_changes_t *changes = item->attributes;
-    sc->hp += changes->hp;
-    sc->phys_atk += changes->attack;
-    sc->phys_def += changes->defense;
-
+    sc->max_hp += changes->max_hp;
+    if ((sc->hp + changes->hp) <= sc->max_hp)
+    {
+        sc->hp += changes->hp;
+    }else
+    {
+        sc->hp += sc->max_hp;
+    }
+    
     sc->phys_atk += changes->phys_atk;
     sc->phys_def += changes->phys_def; 
     sc->mag_atk += changes->mag_atk;
     sc->mag_def += changes->mag_def;
     sc->speed += changes->speed;
+    sc->crit += changes->crit;
+    sc->accuracy += changes->accuracy;
     if ((sc->sp + changes->sp) > sc->max_sp)
     {
         sc->sp = sc->max_sp;
@@ -220,7 +227,5 @@ int stat_changes_add_item_node(stat_changes_t *sc, battle_item_t *item)
     else{
         sc->sp += changes->sp;
     }
-    sc->crit += changes->crit;
-    sc->accuracy += changes->accuracy;
     return SUCCESS;
 }

--- a/src/battle/src/battle_logic.c
+++ b/src/battle/src/battle_logic.c
@@ -213,7 +213,7 @@ int stat_changes_add_item_node(stat_changes_t *sc, battle_item_t *item)
     sc->speed += changes->speed;
     sc->crit += changes->crit;
     sc->accuracy += changes->accuracy;
-    sc->max_sp += changes->max_sp
+    sc->max_sp += changes->max_sp;
     sc->sp += changes->sp;
 
     return SUCCESS;

--- a/src/battle/src/battle_logic.c
+++ b/src/battle/src/battle_logic.c
@@ -205,14 +205,7 @@ int stat_changes_add_item_node(stat_changes_t *sc, battle_item_t *item)
     }
     stat_changes_t *changes = item->attributes;
     sc->max_hp += changes->max_hp;
-    if ((sc->hp + changes->hp) <= sc->max_hp)
-    {
-        sc->hp += changes->hp;
-    }else
-    {
-        sc->hp += sc->max_hp;
-    }
-    
+    sc->hp += changes->hp;    
     sc->phys_atk += changes->phys_atk;
     sc->phys_def += changes->phys_def; 
     sc->mag_atk += changes->mag_atk;
@@ -220,12 +213,8 @@ int stat_changes_add_item_node(stat_changes_t *sc, battle_item_t *item)
     sc->speed += changes->speed;
     sc->crit += changes->crit;
     sc->accuracy += changes->accuracy;
-    if ((sc->sp + changes->sp) > sc->max_sp)
-    {
-        sc->sp = sc->max_sp;
-    }
-    else{
-        sc->sp += changes->sp;
-    }
+    sc->max_sp += changes->max_sp
+    sc->sp += changes->sp;
+
     return SUCCESS;
 }

--- a/src/battle/src/battle_logic.c
+++ b/src/battle/src/battle_logic.c
@@ -109,7 +109,8 @@ int use_battle_item(combatant_t *c, battle_t *battle, char *name)
     if (item->attack)
     {
         consume_battle_item(battle->enemy, item);
-    } else
+    }
+    else
     {
         consume_battle_item(c, item);
     }
@@ -171,7 +172,8 @@ int apply_stat_changes(stat_t* target_stats, stat_changes_t* changes)
     if ((target_stats->sp + changes->sp) <= target_stats->max_sp)
     {
         target_stats->sp += changes->sp;
-    }else
+    }
+    else
     {
         target_stats->sp = target_stats->max_sp;
     }

--- a/src/battle/src/battle_logic.c
+++ b/src/battle/src/battle_logic.c
@@ -2,6 +2,24 @@
 #include "common/utlist.h"
 #include <ctype.h>
 
+
+/* see battle_flow.h */
+int apply_stat_changes(stat_t* target_stats, stat_changes_t* changes)  
+{
+    target_stats->speed += changes->speed;
+    target_stats->max_sp += changes->max_sp;
+    target_stats->sp += changes->sp;
+    target_stats->phys_atk += changes->phys_atk;
+    target_stats->mag_atk += changes->mag_atk;
+    target_stats->phys_def += changes->phys_def;
+    target_stats->mag_def += changes->mag_def;
+    target_stats->crit += changes->crit;
+    target_stats->accuracy += changes->accuracy;
+    target_stats->hp += changes->hp;
+    target_stats->max_hp += changes->max_hp;
+    return SUCCESS;
+}
+
 /* check battle_logic.h */
 combatant_t* check_target(battle_t *b, char *target)
 {

--- a/src/battle/src/battle_logic.c
+++ b/src/battle/src/battle_logic.c
@@ -213,9 +213,11 @@ int stat_changes_add_item_node(stat_changes_t *sc, battle_item_t *item)
     sc->mag_atk += changes->mag_atk;
     sc->mag_def += changes->mag_def;
     sc->speed += changes->speed;
-    if((sc->sp + changes->sp) > sc->max_sp){
+    if ((sc->sp + changes->sp) > sc->max_sp)
+    {
         sc->sp = sc->max_sp;
-    }else{
+    }
+    else{
         sc->sp += changes->sp;
     }
     sc->crit += changes->crit;

--- a/src/battle/src/battle_print.c
+++ b/src/battle/src/battle_print.c
@@ -354,18 +354,55 @@ int *print_battle_items(battle_t *b, char *string)
     DL_FOREACH(player_items, item)
     {
         char* name = item->name;
-        int attack = item->attack;
-        int defense = item->defense;
-        int hp = item->hp;
         int quantity = item->quantity;
 
-        n = snprintf(temp, BATTLE_BUFFER_SIZE, "Name: %s\nAttack: %d\nDefense: %d\nHP: %d\nQuantity: %d\n", name, attack,defense, hp,quantity);
+        n = snprintf(temp, BATTLE_BUFFER_SIZE, "Name: %s\nQuantity: %d\n", name, quantity);
         strncat(string, temp, BATTLE_BUFFER_SIZE - slen);
         slen += n;
     }
 
     return SUCCESS;
    
+}
+/* THIS PR NEEDS TO ACCOUNT FOR THE print_battle_action_menu()
+    from a non merged PR.  */
+
+/* see battle_print.h */
+int *print_battle_item_details(battle_item_t *item, char *string)
+{
+    int slen = strnlen(string, BATTLE_BUFFER_SIZE + 1);
+    int n;
+    char temp[BATTLE_BUFFER_SIZE + 1];
+
+    char* name = item->name;
+    char* description = item->description;
+    stat_changes_t *changes = item->attributes;
+    int phys_atk = changes->phys_atk;
+    int mag_atk = changes->mag_atk;
+    int phys_def = changes->phys_def;
+    int mag_def = changes->mag_def;
+    int max_sp = changes->max_sp;
+    int sp = changes->sp;
+    int max_hp = changes->max_hp;
+    int hp = item->hp;
+    int crit = item->crit;
+    int accuracy = item->accuracy;
+    int quantity = item->quantity;
+
+    n = snprintf(temp, BATTLE_BUFFER_SIZE, "Name: %s\n"
+                "Description: %s\nStat Changes:\n"
+                "\tPhysical Attack: %d\n\tMagical Attack: %d\n"
+                "\tPhysical Defense: %d\n\tMagical Defense: %d\n"
+                "\tMax_SP: %d\n\tSP: %d\n"
+                "\tMax_HP: %d\n\tSP: %d\n"
+                "\tCritical Rate: %d\n\tAccuracy: %d\n"
+                "\nQuantity: %d\n", 
+                name, description, phys_atk, mag_atk, phys_def, mag_def,
+                max_sp, sp, max_hp, hp, crit, accuracy);
+
+    strncat(string, temp, BATTLE_BUFFER_SIZE - slen);
+    slen += n;
+    return SUCCESS;
 }
 
  

--- a/src/battle/src/battle_print.c
+++ b/src/battle/src/battle_print.c
@@ -384,9 +384,9 @@ int *print_battle_item_details(battle_item_t *item, char *string)
     int max_sp = changes->max_sp;
     int sp = changes->sp;
     int max_hp = changes->max_hp;
-    int hp = item->hp;
-    int crit = item->crit;
-    int accuracy = item->accuracy;
+    int hp = changes->hp;
+    int crit = changes->crit;
+    int accuracy = changes->accuracy;
     int quantity = item->quantity;
 
     n = snprintf(temp, BATTLE_BUFFER_SIZE, "Name: %s\n"
@@ -398,7 +398,7 @@ int *print_battle_item_details(battle_item_t *item, char *string)
                 "\tCritical Rate: %d\n\tAccuracy: %d\n"
                 "\nQuantity: %d\n", 
                 name, description, phys_atk, mag_atk, phys_def, mag_def,
-                max_sp, sp, max_hp, hp, crit, accuracy);
+                max_sp, sp, max_hp, hp, crit, accuracy, quantity);
 
     strncat(string, temp, BATTLE_BUFFER_SIZE - slen);
     slen += n;

--- a/src/battle/src/battle_state.c
+++ b/src/battle/src/battle_state.c
@@ -6,8 +6,10 @@
 #include "common/utlist.h"
 
 /* See battle_state.h */
-combatant_t *combatant_new(char *name, bool is_friendly, class_t *c_type, stat_t *stats,
-    move_t *moves, battle_item_t *items, difficulty_t ai)
+combatant_t *combatant_new(char *name, bool is_friendly, class_t *c_type, 
+                            stat_t *stats, move_t *moves, battle_item_t *items, 
+                            battle_equipment_t *weapon, battle_equipment_t *accessory, 
+                            battle_equipment_t *armor,difficulty_t ai)
 {
     combatant_t *c;
     int rc;
@@ -19,7 +21,8 @@ combatant_t *combatant_new(char *name, bool is_friendly, class_t *c_type, stat_t
         return NULL;
     }
 
-    rc = combatant_init(c, name, is_friendly, c_type, stats, moves, items, ai);
+    rc = combatant_init(c, name, is_friendly, c_type, stats, moves, items, weapon,
+                        accesory, armor, ai);
     if(rc != SUCCESS)
     {
         fprintf(stderr, "Could not initialize character\n");
@@ -31,7 +34,8 @@ combatant_t *combatant_new(char *name, bool is_friendly, class_t *c_type, stat_t
 
 /* See battle_state.h */
 int combatant_init(combatant_t *c, char *name, bool is_friendly, class_t *c_type, stat_t *stats,
-    move_t *moves, battle_item_t *items, difficulty_t ai)
+                    move_t *moves, battle_item_t *items, battle_equipment_t *weapon, 
+                    battle_equipment_t *accessory, battle_equipment_t *armor,difficulty_t ai)
 {
     assert(c != NULL);
 
@@ -42,6 +46,9 @@ int combatant_init(combatant_t *c, char *name, bool is_friendly, class_t *c_type
     c->stats = stats;
     c->moves = moves;
     c->items = items;
+    c->weapon = weapon;
+    c->accessory = accessory;
+    c->armor = armor;
     c->ai = ai;
     c->next = NULL;
     c->prev = NULL;
@@ -71,7 +78,6 @@ int combatant_free(combatant_t *c)
     {
         class_free(c->class_type);
     }
-
     move_t *move_elt, *move_tmp;
     DL_FOREACH_SAFE(c->moves, move_elt, move_tmp)
     {

--- a/src/battle/src/battle_state.c
+++ b/src/battle/src/battle_state.c
@@ -22,7 +22,7 @@ combatant_t *combatant_new(char *name, bool is_friendly, class_t *c_type,
     }
 
     rc = combatant_init(c, name, is_friendly, c_type, stats, moves, items, weapon,
-                        accesory, armor, ai);
+                        accessory, armor, ai);
     if(rc != SUCCESS)
     {
         fprintf(stderr, "Could not initialize character\n");

--- a/src/npc/examples/battle_move_example_2021.c
+++ b/src/npc/examples/battle_move_example_2021.c
@@ -316,7 +316,7 @@ chiventure_ctx_t *create_sample_ctx()
     stat_t *stats1 = create_enemy_stats();
     move_t *moves1 = create_enemy_moves();
     add_battle_to_npc(friendly_fiona, 100, stats1, moves1, BATTLE_AI_GREEDY,
-		      CONDITIONAL_FRIENDLY, 98, NULL, NULL);
+		      CONDITIONAL_FRIENDLY, 98, NULL, NULL, NULL, NULL, NULL);
 
 
     /* Add dialogue to friendly npc */
@@ -337,7 +337,7 @@ chiventure_ctx_t *create_sample_ctx()
     stat_t *stats2 = create_enemy_stats();
     move_t *moves2 = create_enemy_moves();
     add_battle_to_npc(hostile_harry, 5, stats2, moves2, BATTLE_AI_GREEDY,
-                      HOSTILE, 0, NULL, NULL);
+                      HOSTILE, 0, NULL, NULL, NULL, NULL, NULL);
 
     /* Add items to hostile npc */
     item_t *potion = item_new("POTION","This is a health potion.",

--- a/src/npc/src/npc.c
+++ b/src/npc/src/npc.c
@@ -217,13 +217,14 @@ int add_convo_to_npc(npc_t *npc, convo_t *c)
 int add_battle_to_npc(npc_t *npc, int health, stat_t *stats, move_t *moves,
                       difficulty_t ai, hostility_t hostility_level,
                       int surrender_level, class_t *class_type, 
-                      battle_item_t *items)
+                      battle_item_t *items, battle_equipment_t *armor,
+                      battle_equipment_t *accessory, battle_equipment_t *weapon)
 {
     assert(npc != NULL);
 
     npc_battle_t *npc_battle = npc_battle_new(health, stats, moves, ai,
                                               hostility_level, surrender_level,
-                                              class_type, items);
+                                              class_type, items, armor, accessory, weapon);
 
     assert(npc_battle != NULL);
 

--- a/src/npc/src/npc_battle.c
+++ b/src/npc/src/npc_battle.c
@@ -20,9 +20,10 @@ int npc_battle_init(npc_battle_t *npc_battle, int health, stat_t* stats,
     npc_battle->surrender_level = surrender_level;
     npc_battle->class_type = class_type;
     npc_battle->items = items;
+    npc_battle->armor = armor;
     npc_battle->accessory = accessory;
     npc_battle->weapon = weapon;
-    npc_battle->armor = armor;
+
 
     return SUCCESS;
 }

--- a/src/npc/src/npc_battle.c
+++ b/src/npc/src/npc_battle.c
@@ -31,7 +31,9 @@ int npc_battle_init(npc_battle_t *npc_battle, int health, stat_t* stats,
 npc_battle_t *npc_battle_new(int health, stat_t* stats, move_t* moves, 
 		                    difficulty_t ai, hostility_t hostility_level, 
 			                int surrender_level, class_t *class_type,
-                            battle_item_t *items)
+                            battle_item_t *items, battle_equipment_t *armor,
+                            battle_equipment_t *accessory, 
+                            battle_equipment_t *weapon)
 {
     npc_battle_t *npc_battle;
     npc_battle = malloc(sizeof(npc_battle_t));

--- a/src/npc/src/npc_battle.c
+++ b/src/npc/src/npc_battle.c
@@ -8,7 +8,8 @@
 int npc_battle_init(npc_battle_t *npc_battle, int health, stat_t* stats,
                     move_t* moves, difficulty_t ai, hostility_t hostility_level,
                     int surrender_level, class_t *class_type, 
-                    battle_item_t *items)
+                    battle_item_t *items, battle_equipment_t *armor,
+                    battle_equipment_t *accessory, battle_equipment_t *weapon)
 {
     assert(npc_battle != NULL);
     npc_battle->health = health;
@@ -19,6 +20,9 @@ int npc_battle_init(npc_battle_t *npc_battle, int health, stat_t* stats,
     npc_battle->surrender_level = surrender_level;
     npc_battle->class_type = class_type;
     npc_battle->items = items;
+    npc_battle->accessory = accessory;
+    npc_battle->weapon = weapon;
+    npc_battle->armor = armor;
 
     return SUCCESS;
 }
@@ -37,10 +41,13 @@ npc_battle_t *npc_battle_new(int health, stat_t* stats, move_t* moves,
     npc_battle->moves = malloc(sizeof(move_t)); 
     npc_battle->class_type = malloc(sizeof(class_t));
     npc_battle->items = malloc(sizeof(battle_item_t));
+    npc_battle->weapon = malloc(sizeof(battle_equipment_t));
+    npc_battle->accessory = malloc(sizeof(battle_equipment_t));
+    npc_battle->armor = malloc(sizeof(battle_equipment_t));
 
     int check = npc_battle_init(npc_battle, health, stats, moves, ai, 
                                 hostility_level, surrender_level, class_type,
-                                items);
+                                items, armor, accessory, weapon);
 
     if (npc_battle == NULL || npc_battle->stats == NULL ||  
         npc_battle->moves == NULL || npc_battle->class_type == NULL || 

--- a/tests/battle/test_battle_ai.c
+++ b/tests/battle/test_battle_ai.c
@@ -30,19 +30,18 @@ move_t *create_move(int id, battle_item_t* item, bool attack, int damage, int de
 */
 
 /* Creates + initializes a battle_item */
- battle_item_t *create_battle_item(int id, int quantity, int durability, char* description,
-            bool battle, int attack, int defense, int hp)
+ battle_item_t *create_battle_item(int id, int quantity, int durability, char* description, 
+                                        char *name, bool attack, stat_changes_t *changes)
  {
      battle_item_t* item = (battle_item_t*) calloc(1, sizeof(battle_item_t));
 
      item->id = id;
-     item->quantity = quantity;
-     item->durability = durability;
+     item->name = name
      item->description = description;
-     item->battle = battle;
+     item->quantity = quantity;
+     item->description = description;
      item->attack = attack;
-     item->hp = hp;
-     item->defense = defense;
+     item->attributes = changes;
 
      return item;
  }
@@ -117,11 +116,26 @@ battle_item_t* create_player_battle_items()
 {
     battle_item_t *head, *dagger, *tea_leaves, *medicine;
     head = NULL;
-    dagger = create_battle_item(1, 1, 20, "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);
-    tea_leaves = create_battle_item(2, 1, 1, "Make yourself a warm cup of tea to heal your wounds!", true,
-    0, 0, 10);
-    medicine = create_battle_item(3, 1, 1, "A first aid kit, straight from your doctor!", true, 0, 0, 30);
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;
+    dagger = create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger"
+    true, dagger_changes;
+
+    stat_changes_t *tea_changes = stat_changes_new();
+    tea_changes->hp = 10;
+    tea_changes->phys_atk = 0;
+    tea_changes->phys_def = 0;
+    tea_leaves = create_battle_item(2, 1, "Make yourself a warm cup of tea to heal your wounds!", "Tea Leaves", 
+                                    true, tea_changes);
+    
+    stat_changes_t *medicine_changes = stat_changes_new();
+    medicine_changes->hp = 30;
+    medicine_changes->phys_atk = 0;
+    medicine_changes->phys_def = 0;
+    medicine = create_battle_item(3, 1, "A first aid kit, straight from your doctor!", "Medicine",
+                                true, medicine_changes);
     DL_APPEND(head, dagger);
     DL_APPEND(head, tea_leaves);
     DL_APPEND(head, medicine);
@@ -131,14 +145,29 @@ battle_item_t* create_player_battle_items()
 /* Creates example hardcoded items for the enemy*/
 battle_item_t* create_enemy_battle_items()
 {
+    /* I am adding these for a temporary fix, however, these will be changed
+       as battle items are no longer weapons */
     battle_item_t *head, *mace, *diamond_sword, *force_shield;
     head = NULL;
-    mace = create_battle_item(4, 1, 20, "Temporary blindness leaves you quite vulnerable...", true,
-        0, -30, 0);
-    diamond_sword = create_battle_item(5, 1, 50, "Brings quick death to those who dare battle you...",
-        true, 20, 0, 0);
-    force_shield = create_battle_item(6, 1, 30, "Rest comfortably as this shield protects you for 1 move",
-        true, 0, 30, 5);
+    stat_changes_t *mace_changes = stat_changes_new();
+    mace_changes->phys_atk = 0;
+    mace_changes->phys_def = -30;
+    mace_changes->hp = 0;
+    mace = create_battle_item(4, 20, "Temporary blindness leaves you quite vulnerable...", "Mace", true,
+                                mace_changes);
+    stat_changes_t *sword_changes = stat_changes_new();
+    sword_changes->phys_atk = 20;
+    sword_changes->phys_def = 0;
+    sword_changes->hp = 0;
+    diamond_sword = create_battle_item(5, 50, "Brings quick death to those who dare battle you...", "Diamond Sword",
+        true, sword_changes);
+
+    stat_changes_t *shield_changes = stat_changes_new();
+    shield_changes->phys_atk = 0;
+    shield_changes->phys_def = 30;
+    shield_changes->hp = 5;    
+    force_shield = create_battle_item(6, 30, "Rest comfortably as this shield protects you for 1 move", "Force Shield"
+        true, shield_changes;
     DL_APPEND(head, mace);
     DL_APPEND(head, diamond_sword);
     DL_APPEND(head, force_shield);

--- a/tests/battle/test_battle_ai.c
+++ b/tests/battle/test_battle_ai.c
@@ -30,13 +30,13 @@ move_t *create_move(int id, battle_item_t* item, bool attack, int damage, int de
 */
 
 /* Creates + initializes a battle_item */
- battle_item_t *create_battle_item(int id, int quantity, int durability, char* description, 
+ battle_item_t *create_battle_item(int id, int quantity, char* description, 
                                         char *name, bool attack, stat_changes_t *changes)
  {
      battle_item_t* item = (battle_item_t*) calloc(1, sizeof(battle_item_t));
 
      item->id = id;
-     item->name = name
+     item->name = name;
      item->description = description;
      item->quantity = quantity;
      item->description = description;

--- a/tests/battle/test_battle_ai.c
+++ b/tests/battle/test_battle_ai.c
@@ -121,7 +121,7 @@ battle_item_t* create_player_battle_items()
     dagger_changes->phys_def = 5;
     dagger_changes->hp = 0;
     dagger = create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
-                                true, dagger_changes;
+                                true, dagger_changes);
 
     stat_changes_t *tea_changes = stat_changes_new();
     tea_changes->hp = 10;
@@ -238,7 +238,7 @@ combatant_t* new_enemy()
     battle_item_t *items = create_enemy_battle_items();
     struct combatant *next = NULL;
     struct combatant *prev = NULL;
-    return combatant_new(name, is_friendly, c_type, stats, moves, items, BATTLE_AI_GREEDY);
+    return combatant_new(name, is_friendly, c_type, stats, moves, items, NULL, NULL, NULL, BATTLE_AI_GREEDY);
 
 }
 
@@ -271,7 +271,7 @@ combatant_t* new_battle_player()
     battle_item_t *items = create_player_battle_items();
     struct combatant *next = NULL;
     struct combatant *prev = NULL;
-    return combatant_new(name, is_friendly, c_type, stats, moves, items, BATTLE_AI_NONE);
+    return combatant_new(name, is_friendly, c_type, stats, moves, items,  NULL, NULL, NULL, BATTLE_AI_NONE);
 }
 
 /* Called by test functions to check give_move returns properly*/

--- a/tests/battle/test_battle_ai.c
+++ b/tests/battle/test_battle_ai.c
@@ -120,8 +120,8 @@ battle_item_t* create_player_battle_items()
     dagger_changes->phys_atk = 20;
     dagger_changes->phys_def = 5;
     dagger_changes->hp = 0;
-    dagger = create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger"
-    true, dagger_changes;
+    dagger = create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes;
 
     stat_changes_t *tea_changes = stat_changes_new();
     tea_changes->hp = 10;
@@ -166,8 +166,8 @@ battle_item_t* create_enemy_battle_items()
     shield_changes->phys_atk = 0;
     shield_changes->phys_def = 30;
     shield_changes->hp = 5;    
-    force_shield = create_battle_item(6, 30, "Rest comfortably as this shield protects you for 1 move", "Force Shield"
-        true, shield_changes;
+    force_shield = create_battle_item(6, 30, "Rest comfortably as this shield protects you for 1 move", "Force Shield",
+                                        true, shield_changes);
     DL_APPEND(head, mace);
     DL_APPEND(head, diamond_sword);
     DL_APPEND(head, force_shield);
@@ -253,7 +253,7 @@ combatant_t* new_enemy_crit()
     battle_item_t *items = create_enemy_battle_items();
     struct combatant *next = NULL;
     struct combatant *prev = NULL;
-    return combatant_new(name, is_friendly, c_type, stats, moves, items, BATTLE_AI_GREEDY);
+    return combatant_new(name, is_friendly, c_type, stats, moves, items, NULL, NULL, NULL, BATTLE_AI_GREEDY);
 
 }
 

--- a/tests/battle/test_battle_default_objects.c
+++ b/tests/battle/test_battle_default_objects.c
@@ -19,7 +19,7 @@ Test(battle_default_objects, default_consumables)
     if (id == 1)
     {
         // Elixir of Life
-        cr_assert_str_eq(test_item->name, "elixir of life ", "get_random_default_consumable() did not set name correctly");
+        cr_assert_str_eq(test_item->name, "Elixir of Life", "get_random_default_consumable() did not set name correctly");
         cr_assert_str_eq(test_item->description, "Adds 50 to your HP!", "get_random_default_consumable() did not set description correctly");
         cr_assert_eq(test_item->attack, false, "get_random_default_consumable() did not set durability correctly");
         cr_assert_eq(test_item->attributes->phys_atk, 0, "get_random_default_consumable() did not set attack correctly");
@@ -31,7 +31,7 @@ Test(battle_default_objects, default_consumables)
     else if (id == 2)
     {
         // Healing Potion
-        cr_assert_str_eq(test_item->name, "healing potion ", "get_random_default_consumable() did not set name correctly");
+        cr_assert_str_eq(test_item->name, "Healing Potion", "get_random_default_consumable() did not set name correctly");
         cr_assert_str_eq(test_item->description, "Adds 20 to your HP!", "get_random_default_consumable() did not set description correctly");
         cr_assert_eq(test_item->attack, false, "get_random_default_consumable() did not set durability correctly");
         cr_assert_eq(test_item->attributes->phys_atk, 0, "get_random_default_consumable() did not set attack correctly");
@@ -43,8 +43,8 @@ Test(battle_default_objects, default_consumables)
     else if (id == 3)
     {
         // Defense Up 
-        cr_assert_str_eq(test_item->name, "defense Up ", "get_random_default_consumable() did not set name correctly");
-        cr_assert_str_eq(test_item->description, "Adds 5 to your defense!", "get_random_default_consumable() did not set description correctly");
+        cr_assert_str_eq(test_item->name, "Defense Up ", "get_random_default_consumable() did not set name correctly");
+        cr_assert_str_eq(test_item->description, "Adds 5 to your Physical Defense!", "get_random_default_consumable() did not set description correctly");
         cr_assert_eq(test_item->attack, false, "get_random_default_consumable() did not set durability correctly");
         cr_assert_eq(test_item->attributes->phys_atk, 0, "get_random_default_consumable() did not set attack correctly");
         cr_assert_eq(test_item->attributes->phys_def, 5, "get_random_default_consumable() did not set defense correctly");
@@ -55,8 +55,8 @@ Test(battle_default_objects, default_consumables)
     else if (id == 4)
     {
         // Strength Up
-        cr_assert_str_eq(test_item->name, "strength up ", "get_random_default_consumable() did not set name correctly %s", test_item->name);
-        cr_assert_str_eq(test_item->description, "Adds 5 to your strength!", "get_random_default_consumable() did not set description correctly");
+        cr_assert_str_eq(test_item->name, "Strength Up ", "get_random_default_consumable() did not set name correctly %s", test_item->name);
+        cr_assert_str_eq(test_item->description, "Adds 5 to your Physical Attack!", "get_random_default_consumable() did not set description correctly");
         cr_assert_eq(test_item->attack, false, "get_random_default_consumable() did not set durability correctly");
         cr_assert_eq(test_item->attributes->phys_atk, 5, "get_random_default_consumable() did not set attack correctly");
         cr_assert_eq(test_item->attributes->phys_def, 0, "get_random_default_consumable() did not set defense correctly");

--- a/tests/battle/test_battle_default_objects.c
+++ b/tests/battle/test_battle_default_objects.c
@@ -55,7 +55,7 @@ Test(battle_default_objects, default_consumables)
     else if (id == 4)
     {
         // Strength Up
-        cr_assert_str_eq(test_item->name, "strength up ", "get_random_default_consumable() did not set name correctly");
+        cr_assert_str_eq(test_item->name, "Strength Up", "get_random_default_consumable() did not set name correctly %s", test_item->name);
         cr_assert_str_eq(test_item->description, "Adds 5 to your strength!", "get_random_default_consumable() did not set description correctly");
         cr_assert_eq(test_item->attack, false, "get_random_default_consumable() did not set durability correctly");
         cr_assert_eq(test_item->attributes->phys_atk, 5, "get_random_default_consumable() did not set attack correctly");

--- a/tests/battle/test_battle_default_objects.c
+++ b/tests/battle/test_battle_default_objects.c
@@ -19,7 +19,7 @@ Test(battle_default_objects, default_consumables)
     if (id == 1)
     {
         // Elixir of Life
-        cr_assert_str_eq(test_item->name, "Elixir of Life", "get_random_default_consumable() did not set name correctly");
+        cr_assert_str_eq(test_item->name, "elixir of life ", "get_random_default_consumable() did not set name correctly");
         cr_assert_str_eq(test_item->description, "Adds 50 to your HP!", "get_random_default_consumable() did not set description correctly");
         cr_assert_eq(test_item->attack, false, "get_random_default_consumable() did not set durability correctly");
         cr_assert_eq(test_item->attributes->phys_atk, 0, "get_random_default_consumable() did not set attack correctly");
@@ -31,7 +31,7 @@ Test(battle_default_objects, default_consumables)
     else if (id == 2)
     {
         // Healing Potion
-        cr_assert_str_eq(test_item->name, "Healing Potion", "get_random_default_consumable() did not set name correctly");
+        cr_assert_str_eq(test_item->name, "healing potion ", "get_random_default_consumable() did not set name correctly");
         cr_assert_str_eq(test_item->description, "Adds 20 to your HP!", "get_random_default_consumable() did not set description correctly");
         cr_assert_eq(test_item->attack, false, "get_random_default_consumable() did not set durability correctly");
         cr_assert_eq(test_item->attributes->phys_atk, 0, "get_random_default_consumable() did not set attack correctly");
@@ -43,7 +43,7 @@ Test(battle_default_objects, default_consumables)
     else if (id == 3)
     {
         // Defense Up 
-        cr_assert_str_eq(test_item->name, "Defense Up", "get_random_default_consumable() did not set name correctly");
+        cr_assert_str_eq(test_item->name, "defense Up ", "get_random_default_consumable() did not set name correctly");
         cr_assert_str_eq(test_item->description, "Adds 5 to your defense!", "get_random_default_consumable() did not set description correctly");
         cr_assert_eq(test_item->attack, false, "get_random_default_consumable() did not set durability correctly");
         cr_assert_eq(test_item->attributes->phys_atk, 0, "get_random_default_consumable() did not set attack correctly");
@@ -55,7 +55,7 @@ Test(battle_default_objects, default_consumables)
     else if (id == 4)
     {
         // Strength Up
-        cr_assert_str_eq(test_item->name, "Strength Up", "get_random_default_consumable() did not set name correctly %s", test_item->name);
+        cr_assert_str_eq(test_item->name, "strength up ", "get_random_default_consumable() did not set name correctly %s", test_item->name);
         cr_assert_str_eq(test_item->description, "Adds 5 to your strength!", "get_random_default_consumable() did not set description correctly");
         cr_assert_eq(test_item->attack, false, "get_random_default_consumable() did not set durability correctly");
         cr_assert_eq(test_item->attributes->phys_atk, 5, "get_random_default_consumable() did not set attack correctly");

--- a/tests/battle/test_battle_default_objects.c
+++ b/tests/battle/test_battle_default_objects.c
@@ -43,7 +43,7 @@ Test(battle_default_objects, default_consumables)
     else if (id == 3)
     {
         // Defense Up 
-        cr_assert_str_eq(test_item->name, "Defense Up ", "get_random_default_consumable() did not set name correctly");
+        cr_assert_str_eq(test_item->name, "Defense Up", "get_random_default_consumable() did not set name correctly");
         cr_assert_str_eq(test_item->description, "Adds 5 to your Physical Defense!", "get_random_default_consumable() did not set description correctly");
         cr_assert_eq(test_item->attack, false, "get_random_default_consumable() did not set durability correctly");
         cr_assert_eq(test_item->attributes->phys_atk, 0, "get_random_default_consumable() did not set attack correctly");
@@ -55,7 +55,7 @@ Test(battle_default_objects, default_consumables)
     else if (id == 4)
     {
         // Strength Up
-        cr_assert_str_eq(test_item->name, "Strength Up ", "get_random_default_consumable() did not set name correctly %s", test_item->name);
+        cr_assert_str_eq(test_item->name, "Strength Up", "get_random_default_consumable() did not set name correctly %s", test_item->name);
         cr_assert_str_eq(test_item->description, "Adds 5 to your Physical Attack!", "get_random_default_consumable() did not set description correctly");
         cr_assert_eq(test_item->attack, false, "get_random_default_consumable() did not set durability correctly");
         cr_assert_eq(test_item->attributes->phys_atk, 5, "get_random_default_consumable() did not set attack correctly");

--- a/tests/battle/test_battle_default_objects.c
+++ b/tests/battle/test_battle_default_objects.c
@@ -19,52 +19,48 @@ Test(battle_default_objects, default_consumables)
     if (id == 1)
     {
         // Elixir of Life
-        cr_assert_eq(test_item->durability, 0, "get_random_default_consumable() did not set durability correctly");   
         cr_assert_str_eq(test_item->name, "Elixir of Life", "get_random_default_consumable() did not set name correctly");
         cr_assert_str_eq(test_item->description, "Adds 50 to your HP!", "get_random_default_consumable() did not set description correctly");
-        cr_assert_eq(test_item->battle, true, "get_random_default_consumable() did not set durability correctly");
-        cr_assert_eq(test_item->attack, 0, "get_random_default_consumable() did not set attack correctly");
-        cr_assert_eq(test_item->defense, 0, "get_random_default_consumable() did not set defense correctly");
-        cr_assert_eq(test_item->hp, 50, "get_random_default_consumable() did not set hp correctly");
+        cr_assert_eq(test_item->attack, false, "get_random_default_consumable() did not set durability correctly");
+        cr_assert_eq(test_item->attributes->phys_atk, 0, "get_random_default_consumable() did not set attack correctly");
+        cr_assert_eq(test_item->attributes->phys_def, 0, "get_random_default_consumable() did not set defense correctly");
+        cr_assert_eq(test_item->attributes->hp, 50, "get_random_default_consumable() did not set hp correctly");
         cr_assert_null(test_item->next, "get_random_default_consumable() did not set item->next correctly");
         cr_assert_null(test_item->prev, "get_random_default_consumable() did not set item->prev correctly");
     }
     else if (id == 2)
     {
         // Healing Potion
-        cr_assert_eq(test_item->durability, 0, "get_random_default_consumable() did not set durability correctly");   
         cr_assert_str_eq(test_item->name, "Healing Potion", "get_random_default_consumable() did not set name correctly");
         cr_assert_str_eq(test_item->description, "Adds 20 to your HP!", "get_random_default_consumable() did not set description correctly");
-        cr_assert_eq(test_item->battle, true, "get_random_default_consumable() did not set durability correctly");
-        cr_assert_eq(test_item->attack, 0, "get_random_default_consumable() did not set attack correctly");
-        cr_assert_eq(test_item->defense, 0, "get_random_default_consumable() did not set defense correctly");
-        cr_assert_eq(test_item->hp, 20, "get_random_default_consumable() did not set hp correctly");
+        cr_assert_eq(test_item->attack, false, "get_random_default_consumable() did not set durability correctly");
+        cr_assert_eq(test_item->attributes->phys_atk, 0, "get_random_default_consumable() did not set attack correctly");
+        cr_assert_eq(test_item->attributes->phys_def, 0, "get_random_default_consumable() did not set defense correctly");
+        cr_assert_eq(test_item->attributes->hp, 20, "get_random_default_consumable() did not set hp correctly");
         cr_assert_null(test_item->next, "get_random_default_consumable() did not set item->next correctly");
         cr_assert_null(test_item->prev, "get_random_default_consumable() did not set item->prev correctly");
     }
     else if (id == 3)
     {
-        // Defense Up
-        cr_assert_eq(test_item->durability, 0, "get_random_default_consumable() did not set durability correctly");   
+        // Defense Up 
         cr_assert_str_eq(test_item->name, "Defense Up", "get_random_default_consumable() did not set name correctly");
         cr_assert_str_eq(test_item->description, "Adds 5 to your defense!", "get_random_default_consumable() did not set description correctly");
-        cr_assert_eq(test_item->battle, true, "get_random_default_consumable() did not set durability correctly");
-        cr_assert_eq(test_item->attack, 0, "get_random_default_consumable() did not set attack correctly");
-        cr_assert_eq(test_item->defense, 5, "get_random_default_consumable() did not set defense correctly");
-        cr_assert_eq(test_item->hp, 0, "get_random_default_consumable() did not set hp correctly");
+        cr_assert_eq(test_item->attack, false, "get_random_default_consumable() did not set durability correctly");
+        cr_assert_eq(test_item->attributes->phys_atk, 0, "get_random_default_consumable() did not set attack correctly");
+        cr_assert_eq(test_item->attributes->phys_def, 5, "get_random_default_consumable() did not set defense correctly");
+        cr_assert_eq(test_item->attributes->hp, 0, "get_random_default_consumable() did not set hp correctly");
         cr_assert_null(test_item->next, "get_random_default_consumable() did not set item->next correctly");
         cr_assert_null(test_item->prev, "get_random_default_consumable() did not set item->prev correctly");
     }
     else if (id == 4)
     {
         // Strength Up
-        cr_assert_eq(test_item->durability, 0, "get_random_default_consumable() did not set durability correctly");   
         cr_assert_str_eq(test_item->name, "strength up ", "get_random_default_consumable() did not set name correctly");
         cr_assert_str_eq(test_item->description, "Adds 5 to your strength!", "get_random_default_consumable() did not set description correctly");
-        cr_assert_eq(test_item->battle, true, "get_random_default_consumable() did not set durability correctly");
-        cr_assert_eq(test_item->attack, 5, "get_random_default_consumable() did not set attack correctly");
-        cr_assert_eq(test_item->defense, 0, "get_random_default_consumable() did not set defense correctly");
-        cr_assert_eq(test_item->hp, 0, "get_random_default_consumable() did not set hp correctly");
+        cr_assert_eq(test_item->attack, false, "get_random_default_consumable() did not set durability correctly");
+        cr_assert_eq(test_item->attributes->phys_atk, 5, "get_random_default_consumable() did not set attack correctly");
+        cr_assert_eq(test_item->attributes->phys_def, 0, "get_random_default_consumable() did not set defense correctly");
+        cr_assert_eq(test_item->attributes->hp, 0, "get_random_default_consumable() did not set hp correctly");
         cr_assert_null(test_item->next, "get_random_default_consumable() did not set item->next correctly");
         cr_assert_null(test_item->prev, "get_random_default_consumable() did not set item->prev correctly");
     }
@@ -76,9 +72,9 @@ Test(battle_default_objects, default_consumables)
 
 Test(battle_default_objects, default_weapon)
 {
-    battle_item_t *test_weapon = get_random_default_weapon();
+    battle_item_t *test_weapon = get_random_offensive_item();
     
-    cr_assert_not_null(test_weapon, "get_random_weapon() failed");
+    cr_assert_not_null(test_weapon, "get_random_offensive_item() failed");
 
     int id = test_weapon->id; 
 
@@ -87,91 +83,79 @@ Test(battle_default_objects, default_weapon)
     if (id == 1)
     {
         // SWORD
-        cr_assert_eq(test_weapon->is_weapon, true, "get_random_weapon() did not set is_weapon correctly"); 
-        cr_assert_eq(test_weapon->durability, 100, "get_random_weapon() did not set durability correctly");   
-        cr_assert_str_eq(test_weapon->name, "Sword", "get_random_weapon() did not set name correctly");
-        cr_assert_str_eq(test_weapon->description, "Reduces enemy's HP by 20", "get_random_weapon() did not set description correctly");
-        cr_assert_eq(test_weapon->battle, true, "get_random_weapon() did not set durability correctly");
-        cr_assert_eq(test_weapon->attack, 0, "get_random_weapon() did not set attack correctly");
-        cr_assert_eq(test_weapon->defense, 0, "get_random_weapon() did not set defense correctly");
-        cr_assert_eq(test_weapon->hp, -20, "get_random_weapon() did not set hp correctly");
-        cr_assert_null(test_weapon->next, "get_random_weapon() did not set item->next correctly");
-        cr_assert_null(test_weapon->prev, "get_random_weapon() did not set item->prev correctly");
+        cr_assert_eq(test_weapon->attack, true, "get_random_offensive_item() did not set attack correctly");    
+        cr_assert_str_eq(test_weapon->name, "Sword", "get_random_offensive_item() did not set name correctly");
+        cr_assert_str_eq(test_weapon->description, "Reduces enemy's HP by 20", "get_random_offensive_item() did not set description correctly");
+        cr_assert_eq(test_weapon->attributes->phys_atk, 0, "get_random_offensive_item() did not set attack correctly");
+        cr_assert_eq(test_weapon->attributes->phys_def, 0, "get_random_offensive_item() did not set defense correctly");
+        cr_assert_eq(test_weapon->attributes->hp, -20, "get_random_offensive_item() did not set hp correctly");
+        cr_assert_null(test_weapon->next, "get_random_offensive_item() did not set item->next correctly");
+        cr_assert_null(test_weapon->prev, "get_random_offensive_item() did not set item->prev correctly");
     }
     else if (id == 2)
     {
         // HAMMER
-        cr_assert_eq(test_weapon->is_weapon, true, "get_random_weapon() did not set is_weapon correctly"); 
-        cr_assert_eq(test_weapon->durability, 80, "get_random_weapon() did not set durability correctly");   
-        cr_assert_str_eq(test_weapon->name, "Hammer", "get_random_weapon() did not set name correctly");
-        cr_assert_str_eq(test_weapon->description, "Reduces enemy's HP by 10", "get_random_weapon() did not set description correctly");
-        cr_assert_eq(test_weapon->battle, true, "get_random_weapon() did not set durability correctly");
-        cr_assert_eq(test_weapon->attack, 0, "get_random_weapon() did not set attack correctly");
-        cr_assert_eq(test_weapon->defense, 0, "get_random_weapon() did not set defense correctly");
-        cr_assert_eq(test_weapon->hp, -10, "get_random_weapon() did not set hp correctly");
-        cr_assert_null(test_weapon->next, "get_random_weapon() did not set item->next correctly");
-        cr_assert_null(test_weapon->prev, "get_random_weapon() did not set item->prev correctly");
+        cr_assert_eq(test_weapon->attack, true, "get_random_offensive_item() did not set attack correctly"); 
+        cr_assert_str_eq(test_weapon->name, "Hammer", "get_random_offensive_item() did not set name correctly");
+        cr_assert_str_eq(test_weapon->description, "Reduces enemy's HP by 10", "get_random_offensive_item() did not set description correctly");
+        cr_assert_eq(test_weapon->attributes->phys_atk, 0, "get_random_offensive_item() did not set attack correctly");
+        cr_assert_eq(test_weapon->attributes->phys_def, 0, "get_random_offensive_item() did not set defense correctly");
+        cr_assert_eq(test_weapon->attributes->hp, -10, "get_random_offensive_item() did not set hp correctly");
+        cr_assert_null(test_weapon->next, "get_random_offensive_item() did not set item->next correctly");
+        cr_assert_null(test_weapon->prev, "get_random_offensive_item() did not set item->prev correctly");
     }
     else if (id == 3)
     {
         // SLIME
-        cr_assert_eq(test_weapon->is_weapon, true, "get_random_weapon() did not set is_weapon correctly"); 
-        cr_assert_eq(test_weapon->durability, 60, "get_random_weapon() did not set durability correctly");   
-        cr_assert_str_eq(test_weapon->name, "Slime", "get_random_weapon() did not set name correctly");
-        cr_assert_str_eq(test_weapon->description, "Reduces enemy's ATTACK by 5", "get_random_weapon() did not set description correctly");
-        cr_assert_eq(test_weapon->battle, true, "get_random_weapon() did not set durability correctly");
-        cr_assert_eq(test_weapon->attack, -5, "get_random_weapon() did not set attack correctly");
-        cr_assert_eq(test_weapon->defense, -2, "get_random_weapon() did not set defense correctly");
-        cr_assert_eq(test_weapon->hp, 0, "get_random_weapon() did not set hp correctly");
-        cr_assert_null(test_weapon->next, "get_random_weapon() did not set item->next correctly");
-        cr_assert_null(test_weapon->prev, "get_random_weapon() did not set item->prev correctly");
+        cr_assert_eq(test_weapon->attack, true, "get_random_offensive_item() did not set attack correctly");  
+        cr_assert_str_eq(test_weapon->name, "Slime", "get_random_offensive_item() did not set name correctly");
+        cr_assert_str_eq(test_weapon->description, "Reduces enemy's ATTACK by 5", "get_random_offensive_item() did not set description correctly");
+        cr_assert_eq(test_weapon->attributes->phys_atk, -5, "get_random_offensive_item() did not set attack correctly");
+        cr_assert_eq(test_weapon->attributes->phys_def, -2, "get_random_offensive_item() did not set defense correctly");
+        cr_assert_eq(test_weapon->attributes->hp, 0, "get_random_offensive_item() did not set hp correctly");
+        cr_assert_null(test_weapon->next, "get_random_offensive_item() did not set item->next correctly");
+        cr_assert_null(test_weapon->prev, "get_random_offensive_item() did not set item->prev correctly");
     }
     else if (id == 4)
     {
         // SLEEPING GAS
-        cr_assert_eq(test_weapon->is_weapon, true, "get_random_weapon() did not set is_weapon correctly"); 
-        cr_assert_eq(test_weapon->durability, 40, "get_random_weapon() did not set durability correctly");   
-        cr_assert_str_eq(test_weapon->name, "Sleeping gas", "get_random_weapon() did not set name correctly");
-        cr_assert_str_eq(test_weapon->description, "Reduces enemy's ATTACK by 10", "get_random_weapon() did not set description correctly");
-        cr_assert_eq(test_weapon->battle, true, "get_random_weapon() did not set durability correctly");
-        cr_assert_eq(test_weapon->attack, -10, "get_random_weapon() did not set attack correctly");
-        cr_assert_eq(test_weapon->defense, -5, "get_random_weapon() did not set defense correctly");
-        cr_assert_eq(test_weapon->hp, 0, "get_random_weapon() did not set hp correctly");
-        cr_assert_null(test_weapon->next, "get_random_weapon() did not set item->next correctly");
-        cr_assert_null(test_weapon->prev, "get_random_weapon() did not set item->prev correctly");
+        cr_assert_eq(test_weapon->attack, true, "get_random_offensive_item() did not set attack correctly"); 
+        cr_assert_str_eq(test_weapon->name, "Sleeping gas", "get_random_offensive_item() did not set name correctly");
+        cr_assert_str_eq(test_weapon->description, "Reduces enemy's ATTACK by 10", "get_random_offensive_item() did not set description correctly");
+        cr_assert_eq(test_weapon->attributes->phys_atk, -10, "get_random_offensive_item() did not set attack correctly");
+        cr_assert_eq(test_weapon->attributes->phys_def, -5, "get_random_offensive_item() did not set defense correctly");
+        cr_assert_eq(test_weapon->attributes->hp, 0, "get_random_offensive_item() did not set hp correctly");
+        cr_assert_null(test_weapon->next, "get_random_offensive_item() did not set item->next correctly");
+        cr_assert_null(test_weapon->prev, "get_random_offensive_item() did not set item->prev correctly");
     }
     else if (id == 5)
     {
         // SQUID INK
-        cr_assert_eq(test_weapon->is_weapon, true, "get_random_weapon() did not set is_weapon correctly"); 
-        cr_assert_eq(test_weapon->durability, 30, "get_random_weapon() did not set durability correctly");   
-        cr_assert_str_eq(test_weapon->name, "Squid ink", "get_random_weapon() did not set name correctly");
-        cr_assert_str_eq(test_weapon->description, "Reduces enemy's DEFENSE by 10", "get_random_weapon() did not set description correctly");
-        cr_assert_eq(test_weapon->battle, true, "get_random_weapon() did not set durability correctly");
-        cr_assert_eq(test_weapon->attack, 0, "get_random_weapon() did not set attack correctly");
-        cr_assert_eq(test_weapon->defense, -10, "get_random_weapon() did not set defense correctly");
-        cr_assert_eq(test_weapon->hp, 0, "get_random_weapon() did not set hp correctly");
-        cr_assert_null(test_weapon->next, "get_random_weapon() did not set item->next correctly");
-        cr_assert_null(test_weapon->prev, "get_random_weapon() did not set item->prev correctly");
+        cr_assert_eq(test_weapon->attack, true, "get_random_offensive_item() did not set attack correctly");  
+        cr_assert_str_eq(test_weapon->name, "Squid ink", "get_random_offensive_item() did not set name correctly");
+        cr_assert_str_eq(test_weapon->description, "Reduces enemy's DEFENSE by 10", "get_random_offensive_item() did not set description correctly");
+        cr_assert_eq(test_weapon->attributes->phys_atk, 0, "get_random_offensive_item() did not set attack correctly");
+        cr_assert_eq(test_weapon->attributes->phys_def, -10, "get_random_offensive_item() did not set defense correctly");
+        cr_assert_eq(test_weapon->attributes->hp, 0, "get_random_offensive_item() did not set hp correctly");
+        cr_assert_null(test_weapon->next, "get_random_offensive_item() did not set item->next correctly");
+        cr_assert_null(test_weapon->prev, "get_random_offensive_item() did not set item->prev correctly");
     }
     else if (id == 6)
     {
         // LAUGHING GAS
-        cr_assert_eq(test_weapon->is_weapon, true, "get_random_weapon() did not set is_weapon correctly"); 
-        cr_assert_eq(test_weapon->durability, 20, "get_random_weapon() did not set durability correctly");   
-        cr_assert_str_eq(test_weapon->name, "Laughing gas", "get_random_weapon() did not set name correctly");
-        cr_assert_eq(test_weapon->battle, true, "get_random_weapon() did not set durability correctly");
-        cr_assert_str_eq(test_weapon->description, "Reduces enemy's DEFENSE by 15", "get_random_weapon() did not set description correctly");
-        cr_assert_eq(test_weapon->attack, 0, "get_random_weapon() did not set attack correctly");
-        cr_assert_eq(test_weapon->defense, -15, "get_random_weapon() did not set defense correctly");
-        cr_assert_eq(test_weapon->hp, 0, "get_random_weapon() did not set hp correctly");
-        cr_assert_null(test_weapon->next, "get_random_weapon() did not set item->next correctly");
-        cr_assert_null(test_weapon->prev, "get_random_weapon() did not set item->prev correctly");
+        cr_assert_eq(test_weapon->attack, true, "get_random_offensive_item() did not set attack correctly"); 
+        cr_assert_str_eq(test_weapon->name, "Laughing gas", "get_random_offensive_item() did not set name correctly");
+        cr_assert_str_eq(test_weapon->description, "Reduces enemy's DEFENSE by 15", "get_random_offensive_item() did not set description correctly");
+        cr_assert_eq(test_weapon->attributes->phys_atk, 0, "get_random_offensive_item() did not set attack correctly");
+        cr_assert_eq(test_weapon->attributes->phys_def, -15, "get_random_offensive_item() did not set defense correctly");
+        cr_assert_eq(test_weapon->attributes->hp, 0, "get_random_offensive_item() did not set hp correctly");
+        cr_assert_null(test_weapon->next, "get_random_offensive_item() did not set item->next correctly");
+        cr_assert_null(test_weapon->prev, "get_random_offensive_item() did not set item->prev correctly");
     }
     
     else
     {
-        cr_assert_fail("get_random_weapon() did not set id correctly");
+        cr_assert_fail("get_random_offensive_item() did not set id correctly");
     }
 }
 

--- a/tests/battle/test_battle_flow.c
+++ b/tests/battle/test_battle_flow.c
@@ -15,21 +15,19 @@ class_t *make_wizard()
     return class_new("Wizard", "Wise", "Old and wise", NULL, NULL, NULL);
 }
 
-/* Creates + initializes a battle_item*/
- battle_item_t *create_npc_battle_item(int id, int quantity, int durability, 
-                            char* description, bool battle, int attack,
-                            int defense, int hp)
+/* Creates + initializes a battle_item */
+ battle_item_t *create_npc_battle_item(int id, int quantity, char* description, 
+                                        char *name, bool attack, stat_changes_t *changes)
  {
      battle_item_t* item = (battle_item_t*) calloc(1, sizeof(battle_item_t));
 
      item->id = id;
-     item->quantity = quantity;
-     item->durability = durability;
+     item->name = name;
      item->description = description;
-     item->battle = battle;
+     item->quantity = quantity;
+     item->description = description;
      item->attack = attack;
-     item->hp = hp;
-     item->defense = defense;
+     item->attributes = changes;
 
      return item;
  }
@@ -44,7 +42,7 @@ Test(battle_flow_move, set_battle_player)
                                 NULL, NULL, NULL);
 
     battle_player_t *ctx_player = new_ctx_player("set_player_Name", test_class,
-                                           NULL, NULL, NULL);
+                                           NULL, NULL, NULL, NULL, NULL, NULL);
 
     comb_player = set_battle_player(ctx_player);
 
@@ -76,10 +74,12 @@ Test(battle_flow_move, set_one_enemy)
     class_t* test_class = class_new("Bard", "Music boi",
                                 "Charismatic, always has a joke or song ready",
                                 NULL, NULL, NULL);
-
-    battle_item_t *dagger = create_npc_battle_item(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);                                 
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;
+    battle_item_t *dagger = create_npc_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);                               
 
     move_t *move = move_new(0, "TEST", "TEST INFO", PHYS, NO_TARGET, NO_TARGET, 
                               SINGLE, 0, NULL, 80, 100, NULL, NULL, NULL, NULL);
@@ -87,7 +87,7 @@ Test(battle_flow_move, set_one_enemy)
     npc_t *npc_enemy = npc_new("enemy_name", "Enemy!", "Enemy!", 
                                 test_class, NULL, true);
     npc_battle_t *npc_b = npc_battle_new(100, stats, move, BATTLE_AI_GREEDY,
-                            HOSTILE, 0, test_class, dagger);
+                            HOSTILE, 0, test_class, dagger, NULL, NULL, NULL);
     npc_enemy->npc_battle = npc_b;
 
     combatant_t *comb_enemy = set_enemy(npc_enemy);
@@ -122,20 +122,22 @@ Test(battle_flow_move, set_battle)
     class_t* test_class = class_new("Bard", "Music boi",
                                 "Charismatic, always has a joke or song ready",
                                 NULL, NULL, NULL);
-
-    battle_item_t *dagger = create_npc_battle_item(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);    
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;
+    battle_item_t *dagger = create_npc_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);
 
     battle_player_t *ctx_player = new_ctx_player("set_battle_name", 
-                                                NULL, NULL, NULL, NULL);
+                                                NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     move_t *move = move_new(0, "TEST", "TEST INFO", PHYS, NO_TARGET, NO_TARGET, 
                               SINGLE, 0, NULL, 80, 100, NULL, NULL, NULL, NULL);
     stat_t *stats = (stat_t*)malloc(sizeof(stat_t));
     npc_t *npc_enemy = npc_new("set_battle_name", "Enemy!", "Enemy!", 
                                     NULL, NULL, true);
     npc_battle_t *npc_b = npc_battle_new(100, stats, move, BATTLE_AI_GREEDY,
-            HOSTILE, 0, test_class, dagger);
+            HOSTILE, 0, test_class, dagger, NULL, NULL, NULL);
     npc_enemy->npc_battle = npc_b;
 
     environment_t env = ENV_DESERT;
@@ -171,14 +173,17 @@ Test(battle_flow_move, start_battle)
                                     "Charismatic, always has a joke or song ready",
                                      NULL, NULL, NULL);
 
-    battle_item_t *dagger = create_npc_battle_item(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);    
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;
+    battle_item_t *dagger = create_npc_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes); 
 
     battle_ctx_t *ctx = calloc(1, sizeof(battle_ctx_t));
     battle_game_t *g = new_battle_game();
     battle_player_t *ctx_player = new_ctx_player("start_battle_Name", 
-                                                NULL, NULL, NULL, NULL);
+                                                NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     g->player = ctx_player;
     ctx->game = g;
     ctx->status = BATTLE_IN_PROGRESS;
@@ -188,7 +193,7 @@ Test(battle_flow_move, start_battle)
     npc_t *npc_enemy = npc_new("start_battle_Name", "Enemy!", "Enemy!", 
                                 NULL, NULL, true);
     npc_battle_t *npc_b = npc_battle_new(100, stats, move, BATTLE_AI_GREEDY,
-            HOSTILE, 0, test_class, dagger);
+            HOSTILE, 0, test_class, dagger, NULL, NULL, NULL);
     npc_enemy->npc_battle = npc_b;
     environment_t env = ENV_SNOW;
 
@@ -210,7 +215,8 @@ Test(battle_flow_move_, return_success_battle_flow_move)
     pstats->phys_def = 30;
     pstats->accuracy = 100;
     pstats->crit = 0;
-    battle_player_t *ctx_player = new_ctx_player("Player", make_wizard(), pstats, NULL, NULL);
+    battle_player_t *ctx_player = new_ctx_player("Player", make_wizard(), pstats, NULL, NULL, 
+                                                NULL, NULL, NULL);
 
     g->player = ctx_player;
     ctx->game = g;
@@ -230,13 +236,15 @@ Test(battle_flow_move_, return_success_battle_flow_move)
     class_t* test_class = class_new("Bard", "Music boi",
                                 "Charismatic, always has a joke or song ready",
                                      NULL, NULL, NULL);
-
-    battle_item_t *dagger = create_npc_battle_item(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0); 
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;
+    battle_item_t *dagger = create_npc_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);
 
     npc_battle_t *npc_b = npc_battle_new(100, estats, e_move, BATTLE_AI_GREEDY,
-            HOSTILE, 0, test_class, dagger);
+            HOSTILE, 0, test_class, dagger, NULL, NULL, NULL);
     npc_enemy->npc_battle = npc_b;
     environment_t env = ENV_WATER;
 
@@ -269,7 +277,8 @@ Test(battle_flow_move, do_damage_battle_flow_move)
     pstats->phys_def = 30;
     pstats->accuracy = 100;
     pstats->crit = 0;
-    battle_player_t *ctx_player = new_ctx_player("Player", make_wizard(), pstats, NULL, NULL);
+    battle_player_t *ctx_player = new_ctx_player("Player", make_wizard(), pstats, NULL, NULL,
+                                                NULL, NULL, NULL);
 
     g->player = ctx_player;
     ctx->game = g;
@@ -288,11 +297,15 @@ Test(battle_flow_move, do_damage_battle_flow_move)
     class_t* test_class = class_new("Bard", "Music boi",
                                 "Charismatic, always has a joke or song ready",
                                 NULL, NULL, NULL);
-    battle_item_t *dagger = create_npc_battle_item(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);    
+    
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;
+    battle_item_t *dagger = create_npc_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);
     npc_battle_t *npc_b = npc_battle_new(100, estats, emove, BATTLE_AI_GREEDY,
-            HOSTILE, 0, test_class, dagger);
+            HOSTILE, 0, test_class, dagger, NULL, NULL, NULL);
     npc_enemy->npc_battle = npc_b;
 
     environment_t env = ENV_WATER;
@@ -350,7 +363,8 @@ Test(battle_flow_move, battle_over_by_player)
     pstats->phys_def = 30;
     pstats->accuracy = 100;
     pstats->crit = 0; 
-    battle_player_t *ctx_player = new_ctx_player("Player", make_wizard(), pstats, NULL, NULL);
+    battle_player_t *ctx_player = new_ctx_player("Player", make_wizard(), pstats, NULL, NULL, 
+                                                NULL, NULL, NULL);
 
     g->player = ctx_player;
     ctx->game = g;
@@ -369,12 +383,15 @@ Test(battle_flow_move, battle_over_by_player)
     class_t* test_class = class_new("Bard", "Music boi",
                                 "Charismatic, always has a joke or song ready",
                                 NULL, NULL, NULL);
-    battle_item_t *dagger = create_npc_battle_item(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);    
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;
+    battle_item_t *dagger = create_npc_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);
     npc_t *npc_enemy = npc_new("enemy", "Enemy!", "Enemy!", NULL, NULL, true);
     npc_battle_t *npc_b = npc_battle_new(100, estats, emove, BATTLE_AI_GREEDY,
-            HOSTILE, 0, test_class, dagger);
+            HOSTILE, 0, test_class, dagger, NULL, NULL, NULL);
     npc_enemy->npc_battle = npc_b;
 
     environment_t env = ENV_WATER;
@@ -433,7 +450,8 @@ Test(battle_flow_move, battle_over_by_enemy)
     pstats->phys_def = 20;
     pstats->accuracy = 100;
     pstats->crit = 0;
-    battle_player_t *ctx_player = new_ctx_player("Player", make_wizard(), pstats, NULL, NULL);
+    battle_player_t *ctx_player = new_ctx_player("Player", make_wizard(), pstats, NULL, NULL, 
+                                                NULL, NULL, NULL);
     g->player = ctx_player;
     ctx->game = g;
     ctx->status = BATTLE_IN_PROGRESS;
@@ -450,11 +468,14 @@ Test(battle_flow_move, battle_over_by_enemy)
     class_t* test_class = class_new("Bard", "Music boi",
                                 "Charismatic, always has a joke or song ready",
                                 NULL, NULL, NULL);
-    battle_item_t *dagger = create_npc_battle_item(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);    
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;
+    battle_item_t *dagger = create_npc_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);
     npc_battle_t *npc_b = npc_battle_new(100, estats, emove, BATTLE_AI_GREEDY,
-            HOSTILE, 0, test_class, dagger);
+            HOSTILE, 0, test_class, dagger, NULL, NULL, NULL);
     npc_enemy->npc_battle = npc_b;
     environment_t env = ENV_WATER;
 
@@ -472,7 +493,6 @@ Test(battle_flow_move, battle_over_by_enemy)
     combatant_t *player = ctx->game->battle->player;
     combatant_t *enemy = ctx->game->battle->enemy;
 
-    //There was a 2*
     int expected_hp = enemy->stats->hp -
                       2*damage(enemy, move, player);  
 

--- a/tests/battle/test_battle_flow_structs.c
+++ b/tests/battle/test_battle_flow_structs.c
@@ -12,7 +12,7 @@ Test(battle_flow_structs, new_ctx_player)
                                     NULL, NULL, NULL);
 
     battle_player_t *ctx_player = new_ctx_player("new_ctx_player_Name", test_class,
-                                          NULL, NULL, NULL);
+                                          NULL, NULL, NULL, NULL, NULL, NULL);
 
     cr_assert_not_null(ctx_player, "new_ctx_player() failed");
     cr_assert_str_eq(ctx_player->player_id, "new_ctx_player_Name", "new_ctx_player() didn't set id");

--- a/tests/battle/test_battle_logic.c
+++ b/tests/battle/test_battle_logic.c
@@ -18,15 +18,15 @@
 Test(battle_logic, target_exists)
 {
     combatant_t *phead = NULL;
-    combatant_t *p = combatant_new("Player", true, NULL, NULL, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *p = combatant_new("Player", true, NULL, NULL, NULL, NULL, NULL, NULL, NULL, BATTLE_AI_NONE);
     DL_APPEND(phead, p);
 
     combatant_t *ehead = NULL;
     combatant_t *c1;
     combatant_t *c2;
 
-    c1 = combatant_new("Goblin Gary", false, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, BATTLE_AI_NONE);
-    c2 = combatant_new("Orc John", false, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, BATTLE_AI_NONE);
+    c1 = combatant_new("Goblin Gary", false, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, NULL, NULL, NULL, BATTLE_AI_NONE);
+    c2 = combatant_new("Orc John", false, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, NULL, NULL, NULL, BATTLE_AI_NONE);
     DL_APPEND(ehead, c1);
     DL_APPEND(ehead, c2);
     cr_assert_not_null(c1, "combatant_new() failed");
@@ -49,15 +49,17 @@ Test(battle_logic, target_exists)
 Test(battle_logic, target_does_not_exist)
 {
     combatant_t* phead = NULL;
-    combatant_t *p = combatant_new("Player", true, NULL, NULL, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *p = combatant_new("Player", true, NULL, NULL, NULL, NULL, NULL, NULL, NULL, BATTLE_AI_NONE);
     DL_APPEND(phead, p);
 
     combatant_t *ehead = NULL;
     combatant_t *c1;
     combatant_t *c2;
 
-    c1 = combatant_new("Goblin Gary", false, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, BATTLE_AI_NONE);
-    c2 = combatant_new("Orc John", false, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, BATTLE_AI_NONE);
+    c1 = combatant_new("Goblin Gary", false, NULL, calloc(1, sizeof(stat_t)), NULL, 
+                        NULL, NULL, NULL, NULL, BATTLE_AI_NONE);
+    c2 = combatant_new("Orc John", false, NULL, calloc(1, sizeof(stat_t)), NULL, 
+                        NULL, NULL, NULL, NULL, BATTLE_AI_NONE);
     DL_APPEND(ehead, c1);
     DL_APPEND(ehead, c2);
     cr_assert_not_null(c1, "combatant_new() failed");
@@ -86,8 +88,10 @@ Test(battle_logic, battle_over_by_battle_player)
     pstats->hp = 0;
     stat_t *estats = calloc(1, sizeof(stat_t));
     estats->hp = 10;
-    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, NULL, BATTLE_AI_NONE);
-    combatant_t *e = combatant_new("Enemy", false, NULL, estats, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *e = combatant_new("Enemy", false, NULL, estats, NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
     cr_assert_not_null(p, "combatant_new() failed");
     cr_assert_not_null(e, "combatant_new() failed");
 
@@ -121,10 +125,14 @@ Test(battle_logic, battle_over_by_enemy)
     stat_t *estats2 = calloc(1, sizeof(stat_t));
     estats2->hp = 0;
 
-    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, NULL, BATTLE_AI_NONE);
-    combatant_t *e = combatant_new("Enemy", false, NULL, estats, NULL, NULL, BATTLE_AI_NONE);
-    combatant_t *e1 = combatant_new("Enemy", false, NULL, estats1, NULL, NULL, BATTLE_AI_NONE);
-    combatant_t *e2 = combatant_new("Enemy", false, NULL, estats2, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *e = combatant_new("Enemy", false, NULL, estats, NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *e1 = combatant_new("Enemy", false, NULL, estats1, NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *e2 = combatant_new("Enemy", false, NULL, estats2, NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
 
     cr_assert_not_null(p, "combatant_new() failed");
     cr_assert_not_null(e, "combatant_new() failed");
@@ -163,10 +171,14 @@ Test(battle_logic, battle_not_over)
     stat_t *estats2 = calloc(1, sizeof(stat_t));
     estats2->hp = 13;
 
-    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, NULL, BATTLE_AI_NONE);
-    combatant_t *e = combatant_new("Enemy", false, NULL, estats, NULL, NULL, BATTLE_AI_NONE);
-    combatant_t *e1 = combatant_new("Enemy", false, NULL, estats1, NULL, NULL, BATTLE_AI_NONE);
-    combatant_t *e2 = combatant_new("Enemy", false, NULL, estats2, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *e = combatant_new("Enemy", false, NULL, estats, NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *e1 = combatant_new("Enemy", false, NULL, estats1, NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *e2 = combatant_new("Enemy", false, NULL, estats2, NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
     cr_assert_not_null(p, "combatant_new() failed");
     cr_assert_not_null(e, "combatant_new() failed");
     cr_assert_not_null(e1, "combatant_new() failed");
@@ -200,15 +212,18 @@ Test(battle_logic, enemy_goes_first)
     estats2->speed = 15;
 
     combatant_t *phead = NULL;
-    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
     cr_assert_not_null(p, "combatant_new() failed");
     DL_APPEND(phead, p);
 
     combatant_t *ehead = NULL;
     combatant_t *c1;
     combatant_t *c2;
-    c1 = combatant_new("Goblin Gary", false, NULL, estats2, NULL, NULL, BATTLE_AI_NONE);
-    c2 = combatant_new("Orc John", false, NULL, estats, NULL, NULL, BATTLE_AI_NONE);
+    c1 = combatant_new("Goblin Gary", false, NULL, estats2, NULL, NULL, 
+                        NULL, NULL, NULL, BATTLE_AI_NONE);
+    c2 = combatant_new("Orc John", false, NULL, estats, NULL, NULL, 
+                        NULL, NULL, NULL, BATTLE_AI_NONE);
     cr_assert_not_null(c1, "combatant_new() failed");
     cr_assert_not_null(c2, "combatant_new() failed");
     DL_APPEND(ehead, c1);
@@ -238,15 +253,18 @@ Test(battle_logic, battle_player_goes_first)
     estats2->speed = 15;
 
     combatant_t *phead = NULL;
-    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, NULL, 
+                        NULL, NULL, NULL, BATTLE_AI_NONE);
     cr_assert_not_null(p, "combatant_new() failed");
     DL_APPEND(phead, p);
 
     combatant_t *ehead = NULL;
     combatant_t *c1;
     combatant_t *c2;
-    c1 = combatant_new("Goblin Gary", false, NULL, estats, NULL, NULL, BATTLE_AI_NONE);
-    c2 = combatant_new("Orc John", false, NULL, estats2, NULL, NULL, BATTLE_AI_NONE);
+    c1 = combatant_new("Goblin Gary", false, NULL, estats, NULL, NULL, 
+                        NULL, NULL, NULL, BATTLE_AI_NONE);
+    c2 = combatant_new("Orc John", false, NULL, estats2, NULL, NULL, 
+                        NULL, NULL, NULL, BATTLE_AI_NONE);
     cr_assert_not_null(c1, "combatant_new() failed");
     cr_assert_not_null(c2, "combatant_new() failed");
     DL_APPEND(ehead, c1);
@@ -276,15 +294,18 @@ Test(battle_logic, same_speed)
     estats2->speed = 45;
 
     combatant_t *phead = NULL;
-    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
     cr_assert_not_null(p, "combatant_new() failed");
     DL_APPEND(phead, p);
 
     combatant_t *ehead = NULL;
     combatant_t *c1;
     combatant_t *c2;
-    c1 = combatant_new("Goblin Gary", false, NULL, estats, NULL, NULL, BATTLE_AI_NONE);
-    c2 = combatant_new("Orc John", false, NULL, estats2, NULL, NULL, BATTLE_AI_NONE);
+    c1 = combatant_new("Goblin Gary", false, NULL, estats, NULL, NULL, 
+                        NULL, NULL, NULL, BATTLE_AI_NONE);
+    c2 = combatant_new("Orc John", false, NULL, estats2, NULL, NULL, 
+                        NULL, NULL, NULL, BATTLE_AI_NONE);
     cr_assert_not_null(c1, "combatant_new() failed");
     cr_assert_not_null(c2, "combatant_new() failed");
     DL_APPEND(ehead, c1);
@@ -340,7 +361,8 @@ Test(battle_logic, do_not_find_item)
     battle_item_t *found = find_battle_item(head, "item2");
     cr_assert_null(found, "find_battle_item() failed!");
 }
-
+/* This test will need to be changed to and instead should call get_random_equip_weapon() */
+/*
 Test(battle_logic, use_battle_weapon)
 {
     stat_t *player_stats = calloc(1, sizeof(stat_t));
@@ -353,9 +375,11 @@ Test(battle_logic, use_battle_weapon)
     enemy_stats->phys_def = 80;
     battle_item_t *weapon = get_random_default_weapon();
 
-    combatant_t *player = combatant_new("player", true, NULL, player_stats, NULL, weapon, BATTLE_AI_NONE);
+    combatant_t *player = combatant_new("player", true, NULL, player_stats, NULL, weapon, 
+                                        NULL, NULL, NULL, BATTLE_AI_NONE);
 
-    combatant_t *enemy = combatant_new("enemy", false, NULL, enemy_stats, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *enemy = combatant_new("enemy", false, NULL, enemy_stats, NULL, NULL, 
+                                        NULL, NULL, NULL, BATTLE_AI_NONE);
 
     battle_t *battle = calloc(1, sizeof(battle_t));
     battle->player = player;
@@ -364,13 +388,12 @@ Test(battle_logic, use_battle_weapon)
     int expected_hp = battle->enemy->stats->hp + weapon->hp;
     int expected_strength = battle->enemy->stats->phys_atk + weapon->attack;
     int expected_defense = battle->enemy->stats->phys_def + weapon->defense; 
-    int expected_durability = weapon->durability - 10;
     use_battle_item(player, battle, weapon->name);
     cr_assert_eq(battle->enemy->stats->hp, expected_hp, "consume_battle_weapon() does correctly set enemy hp after use. Actual: %d, Expected: %d", battle->enemy->stats->hp,expected_hp);
     cr_assert_eq(battle->enemy->stats->phys_atk, expected_strength, "consume_battle_weapon() does correctly set enemy physical attack after use");
     cr_assert_eq(battle->enemy->stats->phys_def, expected_defense, "consume_battle_weapon() does correctly set enemy physical defense after use");
-    cr_assert_eq(player->items->durability, expected_durability, "consume_battle_weapon() does correctly set item durablity after use");
 }
+*/
 
 /*
  * this tests to see if the battle_player tries consuming a battle_item,
@@ -385,14 +408,16 @@ Test(battle_logic, consume_an_battle_item)
     pstats->max_hp = 20;
     pstats->phys_def = 15;
     pstats->phys_atk = 15;
-    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
     cr_assert_not_null(p, "combatant_new() failed");
 
     battle_item_t *i1 = calloc(1, sizeof(battle_item_t));
-    i1->id = 100;
-    i1->attack = 0;
-    i1->defense = 0;
-    i1->hp = 10;
+    stat_changes_t *changes = stat_changes_new();
+    changes->phys_atk = 0;
+    changes->phys_def = 0;
+    changes->hp = 10;
+    i1->attributes = changes;
 
     int res = consume_battle_item(p, i1);
 
@@ -415,18 +440,22 @@ Test(battle_logic, uses_battle_item_correctly)
     battle_item_t *i2;
 
     i1 = calloc(1, sizeof(battle_item_t));
+    stat_changes_t *changes1 = stat_changes_new();
     i1->id = 100;
-    i1->attack = 0;
-    i1->defense = 0;
-    i1->hp = 10;
+    changes1->phys_atk = 0;
+    changes1->phys_def = 0;
+    changes1->hp = 20;
+    i1->attributes = changes1;
     i1->quantity = 2;
     i1->name = "ITEM1";
     
     i2 = calloc(1, sizeof(battle_item_t));
     i2->id = 101;
-    i2->attack = 0;
-    i2->defense = 0;
-    i2->hp = 20;
+    stat_changes_t *changes2 = stat_changes_new();
+    changes2->phys_atk = 101;
+    changes2->phys_def = 0;
+    changes2->hp = 20;
+    i2->attributes = changes2;
     i2->quantity = 2;
     i2->name = "ITEM2";
     
@@ -438,7 +467,8 @@ Test(battle_logic, uses_battle_item_correctly)
     pstats->max_hp = 25;
     pstats->phys_def = 15;
     pstats->phys_atk = 15;
-    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL,head, BATTLE_AI_NONE);
+    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL,head, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
     cr_assert_not_null(p, "combatant_new() failed");
 
     battle_t *battle = calloc(1, sizeof(battle_t));
@@ -456,7 +486,8 @@ Test(battle_logic, uses_battle_item_correctly)
  */
 Test(battle_logic, inventory_empty)
 {
-    combatant_t *p = combatant_new("Player", true, NULL, NULL, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *p = combatant_new("Player", true, NULL, NULL, NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
     battle_t *battle = calloc(1, sizeof(battle_t));
     battle->player = p;
     int res = use_battle_item(p, battle, "item1");
@@ -473,29 +504,32 @@ Test(battle_logic, no_more_battle_items)
     battle_item_t *i2;
 
     i1 = calloc(1, sizeof(battle_item_t));
+    stat_changes_t *changes1 = stat_changes_new();
     i1->id = 100;
-    i1->attack = 0;
-    i1->defense = 0;
-    i1->hp = 10;
+    changes1->phys_atk = 0;
+    changes1->phys_def = 0;
+    changes1->hp = 10;
+    i1->attributes = changes1;
     i1->quantity = 0;
-    i1->name = "item1";
-
+    i1->name = "ITEM1";
+    
     i2 = calloc(1, sizeof(battle_item_t));
     i2->id = 101;
-    i2->attack = 0;
-    i2->defense = 0;
-    i2->hp = 20;
+    stat_changes_t *changes2 = stat_changes_new();
+    changes2->phys_atk = 101;
+    changes2->phys_def = 0;
+    changes2->hp = 20;
+    i2->attributes = changes2;
     i2->quantity = 2;
-    i2->name = "item2";
-    DL_APPEND(head, i1);
-    DL_APPEND(head, i2);
+    i2->name = "ITEM2";
 
     stat_t *pstats = calloc(1, sizeof(stat_t));
     pstats->hp = 15;
     pstats->max_hp = 25;
     pstats->phys_def = 15;
     pstats->phys_atk = 15;
-    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, head, BATTLE_AI_NONE);
+    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, head, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
     battle_t *battle = calloc(1, sizeof(battle_t));
     battle->player = p;
     cr_assert_not_null(p, "combatant_new() failed");
@@ -517,7 +551,8 @@ Test(battle_logic, award_xp)
     double xp_gain = 15;
     stat_t *pstats = calloc(1, sizeof(stat_t));
     pstats->xp = 100;
-    combatant_t *p = combatant_new("Player", true, test_class, pstats, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *p = combatant_new("Player", true, test_class, pstats, NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
     int res = award_xp(p->stats, xp_gain);
 
     cr_assert_eq(res, 0, "award_xp() did not return 0!");
@@ -542,11 +577,12 @@ Test(battle_logic, award_xp)
 Test(stat_changes, add_item_node)
 {
     battle_item_t *i1 = calloc(1, sizeof(battle_item_t));
-    
+    stat_changes_t *changes1 = stat_changes_new();
     i1->id = 100;
-    i1->attack = 0;
-    i1->defense = 0;
-    i1->hp = 10;
+    changes1->phys_atk = 0;
+    changes1->phys_def = 0;
+    changes1->hp = 10;
+    i1->attributes = changes1;
 
     stat_changes_t *sc;
     int rc;
@@ -570,11 +606,14 @@ Test(battle_logic, remove_single_item)
     char *name = calloc(5, sizeof(char));
     char *d = calloc(15, sizeof(char));
     strcpy(name, "item");
-    strcpy(d, "discription");
+    strcpy(d, "description");
+    i1 = calloc(1, sizeof(battle_item_t));
+    stat_changes_t *changes1 = stat_changes_new();
     i1->id = 100;
-    i1->attack = 0;
-    i1->defense = 0;
-    i1->hp = 10;
+    changes1->phys_atk = 0;
+    changes1->phys_def = 0;
+    changes1->hp = 10;
+    i1->attributes = changes1;
     i1->quantity = 1;
     i1->name = name;
     i1->description = d;
@@ -584,7 +623,8 @@ Test(battle_logic, remove_single_item)
     pstats->max_hp = 20;
     pstats->phys_atk = 15;
     pstats->phys_def = 15;
-    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, i1, BATTLE_AI_NONE);
+    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, i1, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
     cr_assert_not_null(p, "combatant_new() failed");
 
     battle_t *battle = calloc(1, sizeof(battle_t));
@@ -602,11 +642,13 @@ Test(battle_logic, remove_item_of_multiple)
 {
     
     battle_item_t *i1 = calloc(1, sizeof(battle_item_t));
-    i1->id = 100;
-    i1->attack = 0;
-    i1->defense = 0;
-    i1->hp = 10;
+    stat_changes_t *changes1 = stat_changes_new();
+    changes1->phys_atk = 0;
+    changes1->phys_def = 0;
+    changes1->hp = 10;
+    i1->attributes = changes1;
     i1->quantity = 1;
+    i1->id = 100;
     i1->name = calloc(6, sizeof(char));
     strcpy(i1->name, "item1");
     i1->description = calloc(15, sizeof(char));
@@ -614,9 +656,11 @@ Test(battle_logic, remove_item_of_multiple)
 
     battle_item_t *i2 = calloc(1, sizeof(battle_item_t));
     i2->id = 101;
-    i2->attack = 0;
-    i2->defense = 0;
-    i2->hp = 15;
+    stat_changes_t *changes2 = stat_changes_new();
+    changes1->phys_atk = 0;
+    changes1->phys_def = 0;
+    changes1->hp = 15;
+    i2->attributes = changes2;
     i2->quantity = 1;
     i2->name = calloc(6, sizeof(char));
     strcpy(i2->name, "item2");
@@ -633,7 +677,8 @@ Test(battle_logic, remove_item_of_multiple)
     pstats->max_hp = 20;
     pstats->phys_def = 15;
     pstats->phys_atk = 15;
-    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, i1, BATTLE_AI_NONE);
+    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, i1, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
     cr_assert_not_null(p, "combatant_new() failed");
 
     battle_t *battle = calloc(1, sizeof(battle_t));
@@ -654,27 +699,30 @@ Test(battle_logic, remove_item_of_multiple)
 Test(battle_logic, remove_last_item_of_multiple)
 {
     battle_item_t *i1 = calloc(1, sizeof(battle_item_t));
-    i1->id = 100;
-    i1->attack = 0;
-    i1->defense = 0;
-    i1->hp = 10;
+    stat_changes_t *changes1 = stat_changes_new();
+    changes1->phys_atk = 0;
+    changes1->phys_def = 0;
+    changes1->hp = 10;
+    i1->attributes = changes1;
     i1->quantity = 1;
+    i1->id = 100;
     i1->name = calloc(6, sizeof(char));
     strcpy(i1->name, "item1");
     i1->description = calloc(15, sizeof(char));
     strcpy(i1->description, "description");
-    
 
     battle_item_t *i2 = calloc(1, sizeof(battle_item_t));
     i2->id = 101;
-    i2->attack = 0;
-    i2->defense = 0;
-    i2->hp = 15;
+    stat_changes_t *changes2 = stat_changes_new();
+    changes1->phys_atk = 0;
+    changes1->phys_def = 0;
+    changes1->hp = 15;
+    i2->attributes = changes2;
     i2->quantity = 1;
     i2->name = calloc(6, sizeof(char));
     strcpy(i2->name, "item2");
     i2->description = calloc(15, sizeof(char));
-    strcpy(i2->description, "description");    
+    strcpy(i2->description, "description");  
 
     i1->next = i2;
     i2->prev = i1;
@@ -684,7 +732,8 @@ Test(battle_logic, remove_last_item_of_multiple)
     pstats->max_hp = 20;
     pstats->phys_def = 15;
     pstats->phys_atk = 15;
-    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, i1, BATTLE_AI_NONE);
+    combatant_t *p = combatant_new("Player", true, NULL, pstats, NULL, i1, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
     cr_assert_not_null(p, "combatant_new() failed");
 
     battle_t *battle = calloc(1, sizeof(battle_t));

--- a/tests/battle/test_battle_move_maker.c
+++ b/tests/battle/test_battle_move_maker.c
@@ -16,7 +16,7 @@ Test(class_moves, bard)
                                     NULL, NULL, NULL);
     
     battle_player_t *player = new_ctx_player("name", test_class,
-                                          NULL, NULL, NULL);
+                                          NULL, NULL, NULL, NULL, NULL, NULL);
     combatant_t *ret_player = set_battle_player(player);
 
     int rc = build_moves(ret_player);
@@ -60,7 +60,7 @@ Test(class_moves, wizard)
                                     NULL, NULL, NULL);
 
     battle_player_t *player = new_ctx_player("new_ctx_player_Name", test_class,
-                                          NULL, NULL, NULL);
+                                          NULL, NULL, NULL, NULL, NULL, NULL);
 
     combatant_t *ret_player = set_battle_player(player);
 
@@ -105,7 +105,7 @@ Test(class_moves, knight)
                                     NULL, NULL, NULL);
 
     battle_player_t *player = new_ctx_player("new_ctx_player_Name", test_class,
-                                          NULL, NULL, NULL);
+                                          NULL, NULL, NULL, NULL, NULL, NULL);
 
     combatant_t *ret_player = set_battle_player(player);
     

--- a/tests/battle/test_battle_print.c
+++ b/tests/battle/test_battle_print.c
@@ -10,21 +10,19 @@
 #include "npc/npc.h"
 #include "npc/npc_battle.h"
 
-/* Creates + initializes a battle_item*/
- battle_item_t *npc_create_battle_item(int id, int quantity, int durability, 
-                            char* description, bool battle, int attack,
-                            int defense, int hp)
+ /* Creates + initializes a battle_item */
+ battle_item_t *npc_create_battle_item(int id, int quantity, char* description, 
+                                        char *name, bool attack, stat_changes_t *changes)
  {
      battle_item_t* item = (battle_item_t*) calloc(1, sizeof(battle_item_t));
 
      item->id = id;
-     item->quantity = quantity;
-     item->durability = durability;
+     item->name = name;
      item->description = description;
-     item->battle = battle;
+     item->quantity = quantity;
+     item->description = description;
      item->attack = attack;
-     item->hp = hp;
-     item->defense = defense;
+     item->attributes = changes;
 
      return item;
  }
@@ -35,18 +33,22 @@ Test(battle_print, print_start_battle)
     // Setting up a battle with set_battle
     stat_t *player_stats = calloc(1,sizeof(stat_t));
     stat_t *enemy_stats = calloc(1,sizeof(stat_t));
-    battle_player_t *ctx_player = new_ctx_player("player_name", NULL, player_stats, NULL, NULL);
+    battle_player_t *ctx_player = new_ctx_player("player_name", NULL, player_stats, NULL, NULL
+                                                , NULL, NULL, NULL);
     move_t *move = move_new(0, "TEST", "TEST INFO", PHYS, NO_TARGET, NO_TARGET, 
                               SINGLE, 0, NULL, 80, 100, NULL, NULL, NULL, NULL);
     npc_t *npc_enemy = npc_new("Bob", "Enemy!", "Enemy!", NULL, NULL, true);
     class_t* test_class = class_new("Bard", "Music boi",
                                 "Charismatic, always has a joke or song ready",
                                 NULL, NULL, NULL);
-    battle_item_t *dagger = npc_create_battle_item(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);  
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;                        
+    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);
     npc_battle_t *npc_b = npc_battle_new(100, enemy_stats, move,
-            BATTLE_AI_GREEDY, HOSTILE, 0, test_class, dagger);
+            BATTLE_AI_GREEDY, HOSTILE, 0, test_class, dagger, NULL, NULL, NULL);
     npc_enemy->npc_battle = npc_b;
     environment_t env = ENV_DESERT;
     battle_t *b = set_battle(ctx_player, npc_enemy, env);
@@ -70,18 +72,22 @@ Test(battle_print, print_hp_one_enemy)
     /* Setting up a battle with set_battle */
     stat_t *player_stats = calloc(1,sizeof(stat_t));
     stat_t *enemy_stats = calloc(1,sizeof(stat_t));
-    battle_player_t *ctx_player = new_ctx_player("player_name", NULL, player_stats, NULL, NULL);
+    battle_player_t *ctx_player = new_ctx_player("player_name", NULL, player_stats, NULL, NULL,
+                                                NULL, NULL, NULL);
     move_t *move = move_new(0, "TEST", "TEST INFO", PHYS, NO_TARGET, NO_TARGET, 
                               SINGLE, 0, NULL, 80, 100, NULL, NULL, NULL, NULL);
     npc_t *npc_enemy = npc_new("Bob", "Enemy!", "Enemy!", NULL, NULL, true);
     class_t* test_class = class_new("Bard", "Music boi",
                                 "Charismatic, always has a joke or song ready",
                                 NULL, NULL, NULL);
-    battle_item_t *dagger = npc_create_battle_item(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;                        
+    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);
     npc_battle_t *npc_b = npc_battle_new(100, enemy_stats, move,
-            BATTLE_AI_GREEDY, HOSTILE, 0, test_class, dagger);
+            BATTLE_AI_GREEDY, HOSTILE, 0, test_class, dagger, NULL, NULL, NULL);
     npc_enemy->npc_battle = npc_b;
     environment_t env = ENV_DESERT;
     battle_t *b = set_battle(ctx_player, npc_enemy, env);
@@ -128,18 +134,22 @@ Test(battle_print, print_player_move)
     enemy_stats->level = 5;
     enemy_stats->speed = 9;
 
-    battle_player_t *ctx_player = new_ctx_player("player_name", NULL, player_stats, NULL, NULL);
+    battle_player_t *ctx_player = new_ctx_player("player_name", NULL, player_stats, NULL, NULL,
+                                                NULL, NULL, NULL);
     move_t *e_move = move_new(0, "TEST", "TEST INFO", PHYS, NO_TARGET, NO_TARGET, 
                               SINGLE, 0, NULL, 80, 100, NULL, NULL, NULL, NULL);
     npc_t *npc_enemy = npc_new("Bob", "Enemy!", "Enemy!", NULL, NULL, true);
     class_t* test_class = class_new("Bard", "Music boi",
                                 "Charismatic, always has a joke or song ready",
                                 NULL, NULL, NULL);
-    battle_item_t *dagger = npc_create_battle_item(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);  
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;                        
+    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);
     npc_battle_t *npc_b = npc_battle_new(100, enemy_stats, e_move, 
-            BATTLE_AI_GREEDY, HOSTILE, 0, test_class, dagger);
+            BATTLE_AI_GREEDY, HOSTILE, 0, test_class, dagger, NULL, NULL, NULL);
     npc_enemy->npc_battle = npc_b;
     environment_t env = ENV_DESERT;
     battle_t *b = set_battle(ctx_player, npc_enemy, env);
@@ -191,18 +201,22 @@ Test(battle_print, print_player_move_crit)
     enemy_stats->level = 5;
     enemy_stats->speed = 9;
 
-    battle_player_t *ctx_player = new_ctx_player("player_name", NULL, player_stats, NULL, NULL);
+    battle_player_t *ctx_player = new_ctx_player("player_name", NULL, player_stats, NULL, NULL,
+                                                NULL, NULL, NULL);
     move_t *e_move = move_new(0, "TEST", "TEST INFO", PHYS, NO_TARGET, NO_TARGET, 
                               SINGLE, 0, NULL, 80, 100, NULL, NULL, NULL, NULL);
     npc_t *npc_enemy = npc_new("Bob", "Enemy!", "Enemy!", NULL, NULL, true);
     class_t* test_class = class_new("Bard", "Music boi",
                             "Charismatic, always has a joke or song ready",
                             NULL, NULL, NULL);
-    battle_item_t *dagger = npc_create_battle_item(1, 1, 20, 
-                "A hearty dagger sure to take your breath away... for good",
-                true, 20, 5, 0); 
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;                        
+    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);
     npc_battle_t *npc_b = npc_battle_new(100, enemy_stats, e_move,
-                     BATTLE_AI_GREEDY, HOSTILE, 0, test_class, dagger);
+                     BATTLE_AI_GREEDY, HOSTILE, 0, test_class, dagger, NULL, NULL, NULL);
     npc_enemy->npc_battle = npc_b;
     environment_t env = ENV_DESERT;
     battle_t *b = set_battle(ctx_player, npc_enemy, env);
@@ -251,18 +265,22 @@ Test(battle_print, print_player_move_miss)
     enemy_stats->level = 5;
     enemy_stats->speed = 9;
 
-    battle_player_t *ctx_player = new_ctx_player("player_name", NULL, player_stats, NULL, NULL);
+    battle_player_t *ctx_player = new_ctx_player("player_name", NULL, player_stats, NULL, NULL,
+                                                NULL, NULL, NULL);
     move_t *e_move = move_new(0, "TEST", "TEST INFO", PHYS, NO_TARGET, NO_TARGET, 
                               SINGLE, 0, NULL, 80, 100, NULL, NULL, NULL, NULL);
     npc_t *npc_enemy = npc_new("Bob", "Enemy!", "Enemy!", NULL, NULL, true);
     class_t* test_class = class_new("Bard", "Music boi",
                                 "Charismatic, always has a joke or song ready",
                                 NULL, NULL, NULL);
-    battle_item_t *dagger = npc_create_battle_item(1, 1, 20, 
-                "A hearty dagger sure to take your breath away... for good",
-                true, 20, 5, 0); 
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;                        
+    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);
     npc_battle_t *npc_b = npc_battle_new(100, enemy_stats, e_move,
-                     BATTLE_AI_GREEDY, HOSTILE, 0, test_class, dagger);
+                     BATTLE_AI_GREEDY, HOSTILE, 0, test_class, dagger, NULL, NULL, NULL);
     npc_enemy->npc_battle = npc_b;
     environment_t env = ENV_DESERT;
     battle_t *b = set_battle(ctx_player, npc_enemy, env);
@@ -313,18 +331,22 @@ Test(battle_print, print_enemy_move)
     enemy_stats->xp = 100;
     enemy_stats->level = 5;
     enemy_stats->speed = 9;
-    battle_player_t *ctx_player = new_ctx_player("player_name", NULL, player_stats, NULL, NULL);
+    battle_player_t *ctx_player = new_ctx_player("player_name", NULL, player_stats, NULL, NULL,
+                                                NULL, NULL, NULL);
     move_t *e_move = move_new(0, "TEST", "TEST INFO", PHYS, NO_TARGET, NO_TARGET, 
                               SINGLE, 0, NULL, 80, 100, NULL, NULL, NULL, NULL);
     npc_t *npc_enemy = npc_new("Bob", "Enemy!", "Enemy!", NULL, NULL, true);
     class_t* test_class = class_new("Bard", "Music boi",
                                 "Charismatic, always has a joke or song ready",
                                 NULL, NULL, NULL);
-    battle_item_t *dagger = npc_create_battle_item(1, 1, 20, 
-                "A hearty dagger sure to take your breath away... for good",
-                true, 20, 5, 0);                                   
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;                        
+    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);                                  
     npc_battle_t *npc_b = npc_battle_new(100, enemy_stats, e_move,
-            BATTLE_AI_GREEDY, HOSTILE, 0, test_class, dagger);
+            BATTLE_AI_GREEDY, HOSTILE, 0, test_class, dagger, NULL, NULL, NULL);
     npc_enemy->npc_battle = npc_b;
     environment_t env = ENV_WATER;
     battle_t *b = set_battle(ctx_player, npc_enemy, env);

--- a/tests/battle/test_battle_state.c
+++ b/tests/battle/test_battle_state.c
@@ -16,7 +16,8 @@ Test(battle_state, combatant_new)
 
     combatant_t *c;
 
-    c = combatant_new("combatant_new_Name", true, test_class, NULL, NULL, NULL, BATTLE_AI_GREEDY);
+    c = combatant_new("combatant_new_Name", true, test_class, NULL, NULL, NULL, 
+                    NULL, NULL, NULL, BATTLE_AI_GREEDY);
 
     cr_assert_not_null(c, "combatant_new() failed");
 
@@ -42,7 +43,8 @@ Test(battle_state, combatant_init)
     combatant_t c;
     int rc;
 
-    rc = combatant_init(&c, "combatant_init_Name",true, NULL, NULL, NULL, NULL, BATTLE_AI_RANDOM);
+    rc = combatant_init(&c, "combatant_init_Name",true, NULL, NULL, NULL, NULL, 
+                        NULL, NULL, NULL, BATTLE_AI_RANDOM);
 
     cr_assert_eq(rc, SUCCESS, "combatant_unit() failed");
 
@@ -57,7 +59,8 @@ Test(battle_state, combatant_free)
     combatant_t *c;
     int rc;
 
-    c = combatant_new("combatant_free_Name", true, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, BATTLE_AI_NONE);
+    c = combatant_new("combatant_free_Name", true, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, 
+                    NULL, NULL, NULL, BATTLE_AI_NONE);
 
     cr_assert_not_null(c, "combatant_new() failed");
 
@@ -74,8 +77,10 @@ Test(battle_state, combatant_free_all)
     combatant_t *c2;
     int rc;
 
-    c1 = combatant_new("combatant_free_Name2", true, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, BATTLE_AI_NONE);
-    c2 = combatant_new("combatant_free_Name1", true, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, BATTLE_AI_NONE);
+    c1 = combatant_new("combatant_free_Name2", true, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, 
+                        NULL, NULL, NULL, BATTLE_AI_NONE);
+    c2 = combatant_new("combatant_free_Name1", true, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, 
+                        NULL, NULL, NULL, BATTLE_AI_NONE);
     DL_APPEND(head, c1);
     DL_APPEND(head, c2);
 
@@ -90,8 +95,10 @@ Test(battle_state, combatant_free_all)
 Test(battle_state, battle_new)
 {
     battle_t *b;
-    combatant_t *p = combatant_new("battle_new_Player", true, NULL, NULL, NULL, NULL, BATTLE_AI_NONE);
-    combatant_t *e = combatant_new("battle_new_Enemy", true, NULL, NULL, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *p = combatant_new("battle_new_Player", true, NULL, NULL, NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *e = combatant_new("battle_new_Enemy", true, NULL, NULL, NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
 
     b = battle_new(p, e, ENV_SNOW, ENEMY);
 
@@ -107,8 +114,10 @@ Test(battle_state, battle_new)
 Test(battle_state, battle_init)
 {
     battle_t b;
-    combatant_t *p = combatant_new("battle_init_Player", true, NULL, NULL, NULL, NULL, BATTLE_AI_NONE);
-    combatant_t *e = combatant_new("battle_init_Enemy", true, NULL, NULL, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *p = combatant_new("battle_init_Player", true, NULL, NULL, NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *e = combatant_new("battle_init_Enemy", true, NULL, NULL, NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
     int rc;
 
     rc = battle_init(&b, p, e, ENV_SNOW, ENEMY);
@@ -127,9 +136,12 @@ Test(battle_state, battle_free)
     battle_t *b;
     int rc;
     combatant_t *p = NULL;
-    combatant_t *p1 = combatant_new("battle_new_Player", true, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, BATTLE_AI_NONE);
-    combatant_t *e1 = combatant_new("battle_new_Enemy", false, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, BATTLE_AI_NONE);
-    combatant_t *e2 = combatant_new("battle_new_Enemy", false, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *p1 = combatant_new("battle_new_Player", true, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *e1 = combatant_new("battle_new_Enemy", false, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
+    combatant_t *e2 = combatant_new("battle_new_Enemy", false, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, 
+                                    NULL, NULL, NULL, BATTLE_AI_NONE);
 
     DL_APPEND(p, p1);
     combatant_t *e = NULL;
@@ -307,7 +319,8 @@ Test(stat_changes, stat_changes_turn_increment_simple_decrement)
     combatant_t *c;
     int rc;
 
-    c = combatant_new("combatant_free_Name", true, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, BATTLE_AI_NONE);
+    c = combatant_new("combatant_free_Name", true, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, 
+                        NULL, NULL, NULL, BATTLE_AI_NONE);
     head = stat_changes_new();
     sc = stat_changes_new();
     sc->turns_left = 2;
@@ -329,7 +342,8 @@ Test(stat_changes, stat_changes_turn_increment_complex_decrement)
     combatant_t *c;
     int rc;
 
-    c = combatant_new("combatant_free_Name", true, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, BATTLE_AI_NONE);
+    c = combatant_new("combatant_free_Name", true, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, 
+                        NULL, NULL, NULL, BATTLE_AI_NONE);
     sc = stat_changes_new();
     head = stat_changes_new();
 
@@ -362,7 +376,8 @@ Test(stat_changes, stat_changes_undo)
     combatant_t *c;
     int rc;
 
-    c = combatant_new("combatant_free_Name", true, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, BATTLE_AI_NONE);
+    c = combatant_new("combatant_free_Name", true, NULL, calloc(1, sizeof(stat_t)), NULL, NULL, 
+                        NULL, NULL, NULL, BATTLE_AI_NONE);
     sc = stat_changes_new();
 
     c->stats->speed = 1;

--- a/tests/npc/test_npc.c
+++ b/tests/npc/test_npc.c
@@ -494,7 +494,7 @@ Test(npc, check_npc_battle)
     dagger_changes1->phys_atk = 20;
     dagger_changes1->phys_def = 5;
     dagger_changes1->hp = 0;                        
-    battle_item_t *dagger = npc_create_battle_item_new(1, "Dagger", "A hearty dagger sure to take your breath away... for good", dagger_changes,
+    battle_item_t *dagger = npc_create_battle_item_new(1, "Dagger", "A hearty dagger sure to take your breath away... for good", dagger_changes1,
                                 20, true);
 
     stat_changes_t *dagger_changes2 = stat_changes_new();

--- a/tests/npc/test_npc.c
+++ b/tests/npc/test_npc.c
@@ -6,7 +6,7 @@
 #include "playerclass/class.h"
 #include "battle/battle_state.h"
 
- battle_item_t *npc_create_battle_item_new(int id, char *name, char* description, stat_changes_t *attributes 
+ battle_item_t *npc_create_battle_item_new(int id, char *name, char* description, stat_changes_t *attributes, 
                                          int quantity, bool attack)
  {
      battle_item_t* item = (battle_item_t*) calloc(1, sizeof(battle_item_t));

--- a/tests/npc/test_npc.c
+++ b/tests/npc/test_npc.c
@@ -6,7 +6,7 @@
 #include "playerclass/class.h"
 #include "battle/battle_state.h"
 
- battle_item_t *npc_create_battle_item(int id, int quantity, char* description, 
+ battle_item_t *npc_create_battle_item_new(int id, int quantity, char* description, 
                                         char *name, bool attack, stat_changes_t *changes)
  {
      battle_item_t* item = (battle_item_t*) calloc(1, sizeof(battle_item_t));
@@ -328,7 +328,7 @@ Test(npc, add_battle_to_npc)
     dagger_changes->phys_atk = 20;
     dagger_changes->phys_def = 5;
     dagger_changes->hp = 0;                        
-    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+    battle_item_t *dagger = npc_create_battle_item_new(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
                                 true, dagger_changes);
 
     int res = add_battle_to_npc(npc, 100, stats, moves, BATTLE_AI_GREEDY, 
@@ -364,7 +364,7 @@ Test(npc, get_npc_battle)
     dagger_changes->phys_atk = 20;
     dagger_changes->phys_def = 5;
     dagger_changes->hp = 0;                        
-    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+    battle_item_t *dagger = npc_create_battle_item_new(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
                                 true, dagger_changes);
 
     int res = add_battle_to_npc(npc, 100, stats, moves, BATTLE_AI_GREEDY,
@@ -398,7 +398,7 @@ Test (npc, change_npc_health)
     dagger_changes->phys_atk = 20;
     dagger_changes->phys_def = 5;
     dagger_changes->hp = 0;                        
-    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+    battle_item_t *dagger = npc_create_battle_item_new(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
                                 true, dagger_changes);
 
     int res = add_battle_to_npc(npc, 80, stats, moves, BATTLE_AI_GREEDY,
@@ -453,7 +453,7 @@ Test(npc, get_npc_health)
     dagger_changes->phys_atk = 20;
     dagger_changes->phys_def = 5;
     dagger_changes->hp = 0;                        
-    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+    battle_item_t *dagger = npc_create_battle_item_new(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
                                 true, dagger_changes);
 
     int res = add_battle_to_npc(npc, 80, stats, moves, BATTLE_AI_GREEDY,
@@ -493,14 +493,14 @@ Test(npc, check_npc_battle)
     dagger_changes1->phys_atk = 20;
     dagger_changes1->phys_def = 5;
     dagger_changes1->hp = 0;                        
-    battle_item_t *dagger1 = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+    battle_item_t *dagger1 = npc_create_battle_item_new(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
                                 true, dagger_changes1);
 
     stat_changes_t *dagger_changes2 = stat_changes_new();
     dagger_changes2->phys_atk = 20;
     dagger_changes2->phys_def = 5;
     dagger_changes2->hp = 0;                        
-    battle_item_t *dagger2 = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+    battle_item_t *dagger2 = npc_create_battle_item_new(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
                                 true, dagger_changes2);
 
     int res = add_battle_to_npc(npc1, 80, stats1, moves1, BATTLE_AI_GREEDY,

--- a/tests/npc/test_npc.c
+++ b/tests/npc/test_npc.c
@@ -4,6 +4,7 @@
 #include "npc/npc.h"
 #include "game-state/item.h"
 #include "playerclass/class.h"
+#include "battle/battle_state.h"
 
  battle_item_t *npc_create_battle_item(int id, int quantity, char* description, 
                                         char *name, bool attack, stat_changes_t *changes)

--- a/tests/npc/test_npc.c
+++ b/tests/npc/test_npc.c
@@ -5,7 +5,7 @@
 #include "game-state/item.h"
 #include "playerclass/class.h"
 
- battle_item_t *generate_test_battle_item(int id, int quantity, char* description, 
+ battle_item_t *npc_create_battle_item(int id, int quantity, char* description, 
                                         char *name, bool attack, stat_changes_t *changes)
  {
      battle_item_t* item = (battle_item_t*) calloc(1, sizeof(battle_item_t));

--- a/tests/npc/test_npc.c
+++ b/tests/npc/test_npc.c
@@ -494,7 +494,7 @@ Test(npc, check_npc_battle)
     dagger_changes1->phys_atk = 20;
     dagger_changes1->phys_def = 5;
     dagger_changes1->hp = 0;                        
-    battle_item_t *dagger = npc_create_battle_item_new(1, "Dagger", "A hearty dagger sure to take your breath away... for good", dagger_changes1,
+    battle_item_t *dagger1 = npc_create_battle_item_new(1, "Dagger", "A hearty dagger sure to take your breath away... for good", dagger_changes1,
                                 20, true);
 
     stat_changes_t *dagger_changes2 = stat_changes_new();

--- a/tests/npc/test_npc.c
+++ b/tests/npc/test_npc.c
@@ -5,22 +5,21 @@
 #include "game-state/item.h"
 #include "playerclass/class.h"
 
-battle_item_t *generate_test_battle_item(int id, int quantity, int durability, 
-                            char* description, bool battle, int attack, int defense, int hp)
-{
+ battle_item_t *generate_test_battle_item(int id, int quantity, char* description, 
+                                        char *name, bool attack, stat_changes_t *changes)
+ {
      battle_item_t* item = (battle_item_t*) calloc(1, sizeof(battle_item_t));
 
      item->id = id;
-     item->quantity = quantity;
-     item->durability = durability;
+     item->name = name;
      item->description = description;
-     item->battle = battle;
+     item->quantity = quantity;
+     item->description = description;
      item->attack = attack;
-     item->hp = hp;
-     item->defense = defense;
+     item->attributes = changes;
 
      return item;
-}
+ }
 
 /* Creates a sample class. Taken from test_class.c */
 class_t *generate_test_class()
@@ -324,12 +323,15 @@ Test(npc, add_battle_to_npc)
     stat_t *stats = create_enemy_stats();
     move_t *moves = create_enemy_moves();
 
-    battle_item_t *dagger = generate_test_battle_item(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;                        
+    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);
 
     int res = add_battle_to_npc(npc, 100, stats, moves, BATTLE_AI_GREEDY, 
-		                HOSTILE, 25, generate_test_class(), dagger);
+		                HOSTILE, 25, generate_test_class(), dagger, NULL, NULL, NULL);
 
     cr_assert_eq(res, SUCCESS, "add_battle_to_npc() failed");
     cr_assert_not_null(npc->npc_battle,
@@ -357,12 +359,16 @@ Test(npc, get_npc_battle)
     stat_t *stats = create_enemy_stats();
     move_t *moves = create_enemy_moves();
 
-    battle_item_t *dagger = generate_test_battle_item(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;                        
+    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);
 
     int res = add_battle_to_npc(npc, 100, stats, moves, BATTLE_AI_GREEDY,
-                                HOSTILE, 25, generate_test_class(), dagger);
+                                HOSTILE, 25, generate_test_class(), dagger,
+                                NULL, NULL, NULL);
     cr_assert_eq(res, SUCCESS, "add_battle_to_npc() failed");
 
     npc_battle_t *npc_battle = get_npc_battle(npc);
@@ -387,12 +393,16 @@ Test (npc, change_npc_health)
     stat_t *stats = create_enemy_stats();
     move_t *moves = create_enemy_moves();
 
-    battle_item_t *dagger = generate_test_battle_item(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;                        
+    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);
 
     int res = add_battle_to_npc(npc, 80, stats, moves, BATTLE_AI_GREEDY,
-                                HOSTILE, 25, generate_test_class(), dagger);
+                                HOSTILE, 25, generate_test_class(), dagger,
+                                NULL, NULL, NULL);
     cr_assert_eq(res, SUCCESS, "add_battle_to_npc() failed");
 
     int health1 = change_npc_health(npc, 30, 100);
@@ -438,12 +448,16 @@ Test(npc, get_npc_health)
     stat_t *stats = create_enemy_stats();
     move_t *moves = create_enemy_moves();
 
-    battle_item_t *dagger = generate_test_battle_item(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;                        
+    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);
 
     int res = add_battle_to_npc(npc, 80, stats, moves, BATTLE_AI_GREEDY,
-                                HOSTILE, 25, generate_test_class(), dagger);
+                                HOSTILE, 25, generate_test_class(), dagger,
+                                NULL, NULL, NULL);
     cr_assert_eq(res, SUCCESS, "add_battle_to_npc() failed");
 
     health = get_npc_health(npc);
@@ -474,19 +488,27 @@ Test(npc, check_npc_battle)
     stat_t *stats2 = create_enemy_stats();
     move_t *moves2 = create_enemy_moves();
 
-    battle_item_t *dagger1 = generate_test_battle_item(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);
+    stat_changes_t *dagger_changes1 = stat_changes_new();
+    dagger_changes1->phys_atk = 20;
+    dagger_changes1->phys_def = 5;
+    dagger_changes1->hp = 0;                        
+    battle_item_t *dagger1 = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes1);
 
-    battle_item_t *dagger2 = generate_test_battle_item(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);
+    stat_changes_t *dagger_changes2 = stat_changes_new();
+    dagger_changes2->phys_atk = 20;
+    dagger_changes2->phys_def = 5;
+    dagger_changes2->hp = 0;                        
+    battle_item_t *dagger2 = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes2);
 
     int res = add_battle_to_npc(npc1, 80, stats1, moves1, BATTLE_AI_GREEDY,
-                                HOSTILE, 25, generate_test_class(), dagger1);
+                                HOSTILE, 25, generate_test_class(), dagger1,
+                                NULL, NULL, NULL);
     cr_assert_eq(res, SUCCESS, "add_battle_to_npc() failed");
     res = add_battle_to_npc(npc2, 80, stats2, moves2, BATTLE_AI_GREEDY,
-                                HOSTILE, 25, generate_test_class(), dagger2);
+                                HOSTILE, 25, generate_test_class(), dagger2,
+                                NULL, NULL, NULL);
     cr_assert_eq(res, SUCCESS, "add_battle_to_npc() failed");
 
     cr_assert_eq(check_npc_battle(npc1), true,

--- a/tests/npc/test_npc.c
+++ b/tests/npc/test_npc.c
@@ -6,18 +6,19 @@
 #include "playerclass/class.h"
 #include "battle/battle_state.h"
 
- battle_item_t *npc_create_battle_item_new(int id, int quantity, char* description, 
-                                        char *name, bool attack, stat_changes_t *changes)
+ battle_item_t *npc_create_battle_item_new(int id, char *name, char* description, stat_changes_t *attributes 
+                                         int quantity, bool attack)
  {
      battle_item_t* item = (battle_item_t*) calloc(1, sizeof(battle_item_t));
 
      item->id = id;
      item->name = name;
      item->description = description;
+     item->attributes = attributes;
      item->quantity = quantity;
      item->description = description;
      item->attack = attack;
-     item->attributes = changes;
+     
 
      return item;
  }
@@ -328,8 +329,8 @@ Test(npc, add_battle_to_npc)
     dagger_changes->phys_atk = 20;
     dagger_changes->phys_def = 5;
     dagger_changes->hp = 0;                        
-    battle_item_t *dagger = npc_create_battle_item_new(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
-                                true, dagger_changes);
+    battle_item_t *dagger = npc_create_battle_item_new(1, "Dagger", "A hearty dagger sure to take your breath away... for good", dagger_changes,
+                                20, true);
 
     int res = add_battle_to_npc(npc, 100, stats, moves, BATTLE_AI_GREEDY, 
 		                HOSTILE, 25, generate_test_class(), dagger, NULL, NULL, NULL);
@@ -364,8 +365,8 @@ Test(npc, get_npc_battle)
     dagger_changes->phys_atk = 20;
     dagger_changes->phys_def = 5;
     dagger_changes->hp = 0;                        
-    battle_item_t *dagger = npc_create_battle_item_new(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
-                                true, dagger_changes);
+    battle_item_t *dagger = npc_create_battle_item_new(1, "Dagger", "A hearty dagger sure to take your breath away... for good", dagger_changes,
+                                20, true);
 
     int res = add_battle_to_npc(npc, 100, stats, moves, BATTLE_AI_GREEDY,
                                 HOSTILE, 25, generate_test_class(), dagger,
@@ -398,8 +399,8 @@ Test (npc, change_npc_health)
     dagger_changes->phys_atk = 20;
     dagger_changes->phys_def = 5;
     dagger_changes->hp = 0;                        
-    battle_item_t *dagger = npc_create_battle_item_new(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
-                                true, dagger_changes);
+    battle_item_t *dagger = npc_create_battle_item_new(1, "Dagger", "A hearty dagger sure to take your breath away... for good", dagger_changes,
+                                20, true);
 
     int res = add_battle_to_npc(npc, 80, stats, moves, BATTLE_AI_GREEDY,
                                 HOSTILE, 25, generate_test_class(), dagger,
@@ -453,8 +454,8 @@ Test(npc, get_npc_health)
     dagger_changes->phys_atk = 20;
     dagger_changes->phys_def = 5;
     dagger_changes->hp = 0;                        
-    battle_item_t *dagger = npc_create_battle_item_new(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
-                                true, dagger_changes);
+    battle_item_t *dagger = npc_create_battle_item_new(1, "Dagger", "A hearty dagger sure to take your breath away... for good", dagger_changes,
+                                20, true);
 
     int res = add_battle_to_npc(npc, 80, stats, moves, BATTLE_AI_GREEDY,
                                 HOSTILE, 25, generate_test_class(), dagger,
@@ -493,15 +494,15 @@ Test(npc, check_npc_battle)
     dagger_changes1->phys_atk = 20;
     dagger_changes1->phys_def = 5;
     dagger_changes1->hp = 0;                        
-    battle_item_t *dagger1 = npc_create_battle_item_new(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
-                                true, dagger_changes1);
+    battle_item_t *dagger = npc_create_battle_item_new(1, "Dagger", "A hearty dagger sure to take your breath away... for good", dagger_changes,
+                                20, true);
 
     stat_changes_t *dagger_changes2 = stat_changes_new();
     dagger_changes2->phys_atk = 20;
     dagger_changes2->phys_def = 5;
     dagger_changes2->hp = 0;                        
-    battle_item_t *dagger2 = npc_create_battle_item_new(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
-                                true, dagger_changes2);
+    battle_item_t *dagger2 = npc_create_battle_item_new(1, "Dagger", "A hearty dagger sure to take your breath away... for good", dagger_changes2,
+                                20, true);
 
     int res = add_battle_to_npc(npc1, 80, stats1, moves1, BATTLE_AI_GREEDY,
                                 HOSTILE, 25, generate_test_class(), dagger1,

--- a/tests/npc/test_npc_battle.c
+++ b/tests/npc/test_npc_battle.c
@@ -7,18 +7,18 @@
 #include "battle/battle_moves.h"
 
 /* Creates a sample battle item. Taken from test_battle_ai.c */
- battle_item_t *npc_create_battle_item(int id, int quantity, char* description, 
-                                        char *name, bool attack, stat_changes_t *changes)
+ battle_item_t *npc_create_battle_item(int id, char *name, char* description, 
+                                         stat_changes_t *attributes, int quantity, bool attack)
  {
      battle_item_t* item = (battle_item_t*) calloc(1, sizeof(battle_item_t));
 
      item->id = id;
      item->name = name;
      item->description = description;
+     item->attributes = attributes;
      item->quantity = quantity;
-     item->description = description;
      item->attack = attack;
-     item->attributes = changes;
+     
 
      return item;
  }
@@ -128,8 +128,8 @@ Test(npc_battle, new)
     dagger_changes->phys_atk = 20;
     dagger_changes->phys_def = 5;
     dagger_changes->hp = 0;                        
-    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
-                                true, dagger_changes);
+    battle_item_t *dagger = npc_create_battle_item(1, "Dagger", "A hearty dagger sure to take your breath away... for good", dagger_changes,
+                                20, true);
 
     npc_battle = npc_battle_new(100, stats, moves, BATTLE_AI_GREEDY, 
 		                HOSTILE, 25, generate_npcbattle_test_class(), dagger,
@@ -166,8 +166,8 @@ Test(npc_battle, init)
     dagger_changes->phys_atk = 20;
     dagger_changes->phys_def = 5;
     dagger_changes->hp = 0;                        
-    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
-                                true, dagger_changes);
+    battle_item_t *dagger = npc_create_battle_item(1, "Dagger", "A hearty dagger sure to take your breath away... for good", dagger_changes,
+                                20, true);
 
     npc_battle = npc_battle_new(100, stats1, moves1, BATTLE_AI_GREEDY,
                                 HOSTILE, 25, generate_npcbattle_test_class(),
@@ -207,8 +207,8 @@ Test(npc_battle, free)
     dagger_changes->phys_atk = 20;
     dagger_changes->phys_def = 5;
     dagger_changes->hp = 0;                        
-    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
-                                true, dagger_changes);
+    battle_item_t *dagger = npc_create_battle_item(1, "Dagger", "A hearty dagger sure to take your breath away... for good", dagger_changes,
+                                20, true);
 
     npc_battle = npc_battle_new(100, stats, moves, BATTLE_AI_GREEDY,
                                 HOSTILE, 25, generate_npcbattle_test_class(),
@@ -246,8 +246,8 @@ Test(npc_battle, transfer_all_npc_items_dead)
     dagger_changes->phys_atk = 20;
     dagger_changes->phys_def = 5;
     dagger_changes->hp = 0;                        
-    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
-                                true, dagger_changes);
+    battle_item_t *dagger = npc_create_battle_item(1, "Dagger", "A hearty dagger sure to take your breath away... for good", dagger_changes,
+                                20, true);
 
     add_battle_to_npc(npc, 0, stats, moves, BATTLE_AI_GREEDY, HOSTILE,
             25, generate_npcbattle_test_class(), dagger, NULL, NULL, NULL);
@@ -297,8 +297,8 @@ Test(npc_battle, transfer_all_npc_items_alive)
     dagger_changes->phys_atk = 20;
     dagger_changes->phys_def = 5;
     dagger_changes->hp = 0;                        
-    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
-                                true, dagger_changes);
+    battle_item_t *dagger = npc_create_battle_item(1, "Dagger", "A hearty dagger sure to take your breath away... for good", dagger_changes,
+                                20, true);
 
     add_battle_to_npc(npc, 100, stats, moves, BATTLE_AI_GREEDY, HOSTILE,
             25, generate_npcbattle_test_class(), dagger, NULL, NULL, NULL);
@@ -342,8 +342,8 @@ Test(npc_battle, transfer_all_npc_items_empty_inventory)
     dagger_changes->phys_atk = 20;
     dagger_changes->phys_def = 5;
     dagger_changes->hp = 0;                        
-    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
-                                true, dagger_changes);
+    battle_item_t *dagger = npc_create_battle_item(1, "Dagger", "A hearty dagger sure to take your breath away... for good", dagger_changes,
+                                20, true);
 
     add_battle_to_npc(npc, 0, stats, moves, BATTLE_AI_GREEDY, HOSTILE,
             25, generate_npcbattle_test_class(), dagger, NULL, NULL, NULL);

--- a/tests/npc/test_npc_battle.c
+++ b/tests/npc/test_npc_battle.c
@@ -7,23 +7,21 @@
 #include "battle/battle_moves.h"
 
 /* Creates a sample battle item. Taken from test_battle_ai.c */
-battle_item_t *generate_npc_test_battleitem(int id, int quantity, 
-                            int durability,  char* description, 
-                            bool battle, int attack, int defense, int hp)
-{
+ battle_item_t *npc_create_battle_item(int id, int quantity, char* description, 
+                                        char *name, bool attack, stat_changes_t *changes)
+ {
      battle_item_t* item = (battle_item_t*) calloc(1, sizeof(battle_item_t));
 
      item->id = id;
-     item->quantity = quantity;
-     item->durability = durability;
+     item->name = name;
      item->description = description;
-     item->battle = battle;
+     item->quantity = quantity;
+     item->description = description;
      item->attack = attack;
-     item->hp = hp;
-     item->defense = defense;
+     item->attributes = changes;
 
      return item;
-}
+ }
 
 /* Creates a sample class. Taken from test_class.c */
 class_t *generate_npcbattle_test_class()
@@ -126,12 +124,16 @@ Test(npc_battle, new)
     stat_t *stats = create_enemy_stats1();
     move_t *moves = create_enemy_moves1();
 
-    battle_item_t *dagger = generate_npc_test_battleitem(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;                        
+    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);
 
     npc_battle = npc_battle_new(100, stats, moves, BATTLE_AI_GREEDY, 
-		                HOSTILE, 25, generate_npcbattle_test_class(), dagger);
+		                HOSTILE, 25, generate_npcbattle_test_class(), dagger,
+                        NULL, NULL, NULL);
 
     cr_assert_not_null(npc_battle, "npc_battle_new() failed");
 
@@ -160,17 +162,21 @@ Test(npc_battle, init)
     stat_t *stats2 = create_enemy_stats2();
     move_t *moves2 = create_enemy_moves2();
 
-    battle_item_t *dagger = generate_npc_test_battleitem(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;                        
+    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);
 
     npc_battle = npc_battle_new(100, stats1, moves1, BATTLE_AI_GREEDY,
                                 HOSTILE, 25, generate_npcbattle_test_class(),
-                                dagger);
+                                dagger, NULL, NULL, NULL);
     cr_assert_not_null(npc_battle, "npc_battle_new() failed");
 
     int res = npc_battle_init(npc_battle, 5, stats2, moves2, BATTLE_AI_NONE,
-		              FRIENDLY, 0, generate_npcbattle_test_class(), dagger);
+		                FRIENDLY, 0, generate_npcbattle_test_class(), dagger,
+                        NULL, NULL, NULL);
 
     cr_assert_eq(res, SUCCESS, "npc_battle_init() failed");
 
@@ -197,13 +203,16 @@ Test(npc_battle, free)
     stat_t *stats = create_enemy_stats1();
     move_t *moves = create_enemy_moves1();
 
-    battle_item_t *dagger = generate_npc_test_battleitem(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;                        
+    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);
 
     npc_battle = npc_battle_new(100, stats, moves, BATTLE_AI_GREEDY,
                                 HOSTILE, 25, generate_npcbattle_test_class(),
-                                dagger);
+                                dagger, NULL, NULL, NULL);
 
     cr_assert_not_null(npc_battle, "npc_battle_new() failed");
 
@@ -233,12 +242,15 @@ Test(npc_battle, transfer_all_npc_items_dead)
     cr_assert_not_null(test_item3, "item_new() 3 failed");
     cr_assert_not_null(room, "room_new() failed");
 
-    battle_item_t *dagger = generate_npc_test_battleitem(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;                        
+    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);
 
     add_battle_to_npc(npc, 0, stats, moves, BATTLE_AI_GREEDY, HOSTILE,
-            25, generate_npcbattle_test_class(), dagger);
+            25, generate_npcbattle_test_class(), dagger, NULL, NULL, NULL);
     add_item_to_npc(npc, test_item1);
     add_item_to_npc(npc, test_item2);
     add_item_to_npc(npc, test_item3);
@@ -281,12 +293,15 @@ Test(npc_battle, transfer_all_npc_items_alive)
     cr_assert_not_null(test_item3, "item_new() 3 failed");
     cr_assert_not_null(room, "room_new() failed");
 
-    battle_item_t *dagger = generate_npc_test_battleitem(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;                        
+    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);
 
     add_battle_to_npc(npc, 100, stats, moves, BATTLE_AI_GREEDY, HOSTILE,
-            25, generate_npcbattle_test_class(), dagger);
+            25, generate_npcbattle_test_class(), dagger, NULL, NULL, NULL);
     add_item_to_npc(npc, test_item1);
     add_item_to_npc(npc, test_item2);
     add_item_to_npc(npc, test_item3);
@@ -323,12 +338,15 @@ Test(npc_battle, transfer_all_npc_items_empty_inventory)
     cr_assert_not_null(npc, "npc_new() failed");
     cr_assert_not_null(room, "room_new() failed");
 
-    battle_item_t *dagger = generate_npc_test_battleitem(1, 1, 20, 
-    "A hearty dagger sure to take your breath away... for good",
-    true, 20, 5, 0);
+    stat_changes_t *dagger_changes = stat_changes_new();
+    dagger_changes->phys_atk = 20;
+    dagger_changes->phys_def = 5;
+    dagger_changes->hp = 0;                        
+    battle_item_t *dagger = npc_create_battle_item(1, 20, "A hearty dagger sure to take your breath away... for good", "Dagger",
+                                true, dagger_changes);
 
     add_battle_to_npc(npc, 0, stats, moves, BATTLE_AI_GREEDY, HOSTILE,
-            25, generate_npcbattle_test_class(), dagger);
+            25, generate_npcbattle_test_class(), dagger, NULL, NULL, NULL);
 
     cr_assert_not_null(npc->npc_battle, "add_battle_to_npc() failed");
     cr_assert_null(npc->inventory, "npc->inventory not NULL");


### PR DESCRIPTION
The goal of this pull request was to revamp the battle_item_t data structure to account for more stat changes, and to add battle_equipment_t as outlined in this design [doc](https://github.com/uchicago-cs/chiventure/wiki/Items-~-Equipment-~-Design-Document). A big change with this PR is that we have an entirely new data type battle_equipment, which enhances a player's stats when they enter a battle. Other changes include having stat changes in our battle_item_t data structure as well as allowing combatants to have three different types of equipment: weapon, armor, and accessory. With these new additions, battles are even more customizable battles.