### PR TITLE
Quest/free

### DIFF
--- a/include/quests/quests_state.h
+++ b/include/quests/quests_state.h
@@ -221,6 +221,18 @@ int active_mission_free(active_mission_t *mission);
  */
 int task_free(task_t *task);
 
+/*
+ * Frees a task tree from memory and its nodes
+ *
+ * Parameter:
+ * - task_tree: the task tree to be freed
+ *
+ * Returns:
+ * - SUCCESS for successful free
+ * - FAILURE for unsuccessful free
+ */
+int task_tree_free(task_tree_t *task_tree);
+
 /* 
  * Frees a quest struct from memory including the task list
  * and reward, but otherwise does not free associated pointers

--- a/src/quests/src/quests_state.c
+++ b/src/quests/src/quests_state.c
@@ -246,7 +246,7 @@ int task_tree_free(task_tree_t *task_tree)
     if (task_tree == NULL){
         return SUCCESS;
     } else {
-    free(task_tree->task);
+    task_free(task_tree->task);
     task_tree_free(task_tree->parent);
     task_tree_free(task_tree->rsibling);
     task_tree_free(task_tree->lmostchild);

--- a/src/quests/src/quests_state.c
+++ b/src/quests/src/quests_state.c
@@ -243,13 +243,18 @@ int task_free(task_t *task)
 /* Refer to quests_state.h */
 int task_tree_free(task_tree_t *task_tree)
 {
-    assert(task_tree != NULL);
-
+    if (task_tree == NULL){
+        return SUCCESS;
+    } else {
     free(task_tree->task);
     task_tree_free(task_tree->parent);
     task_tree_free(task_tree->rsibling);
     task_tree_free(task_tree->lmostchild);
     free(task_tree);
+    }
+
+
+
 }
 
 /* Refer to quests_state.h */
@@ -383,10 +388,12 @@ int add_task_to_quest(quest_t *quest, task_t *task_to_add, char *parent_id)
         quest->task_tree = tree;
         return SUCCESS;
     }
-    tree = find_task_in_tree(quest->task_tree, parent_id);
-    assert(tree != NULL);
+    task_t *t = find_task_in_tree(quest->task_tree, parent_id);
+    if (t == NULL){ 
+        return FAILURE; 
+    }
 
-    if (tree->lmostchild == NULL)
+    if (quest->task_tree->lmostchild == NULL)
     {
         tree->lmostchild = malloc(sizeof(task_tree_t));
         tree->lmostchild->task = task_to_add;
@@ -433,36 +440,6 @@ int fail_quest(quest_t *quest, player_t *player)
     pquest->completion = -1;
 
     return SUCCESS;
-}
-
-/*
- * Traverses the task tree to find the task with the
- * given string identifier along a valid quest path.
- *
- * Parameters:
- * - tree: pointer to the task tree to be traversed
- * - id: pointer to a string identifier for the desired task
- *
- * Returns:
- * - pointer to the desired task, OR
- * - NULL if task cannot be found along a valid path
- *
- * Note: Traversal no longer relies on task completion, so 
- *       runtime is now O(T) where T is the number of tasks
- *       in the game
- */
-task_t *find_task_in_tree(task_tree_t *tree, char *id)
-{
-    task_t *task = tree->task;
-
-    assert(task != NULL);
-
-    if (strcmp(task->id, id) == 0)
-    {
-        return task;
-    }
-    task = find_task_in_tree(tree->rsibling, id);
-    return (task != NULL) ? task : find_task_in_tree(tree->lmostchild, id);
 }
 
 /* Refer to quests_state.h */

--- a/tests/quests/test_quests_state.c
+++ b/tests/quests/test_quests_state.c
@@ -249,8 +249,46 @@ Test(task, free)
 	cr_assert_eq(freed, SUCCESS, "task_free() test has failed!");
 }
 
-/* Tests passive_mission_free function */
-Test(active_mission, free)
+Test(task_tree, free)
+{
+    item_t *parent_item = item_new("parent test item", "item for testing",
+    "test item");
+    item_t *child_item = item_new("child test item", "item", "test item");
+    active_mission_t *pa_mission = active_mission_new(parent_item, NULL, NULL, NULL);
+    mission_t *pmission = malloc(sizeof(mission_t));
+    pmission->a_mission = pa_mission;
+    pmission->p_mission = NULL;
+    mission_t *cmission = malloc(sizeof(mission_t));
+    passive_mission_t *cp_mission = passive_mission_new(3, 50, 40);
+    cmission->a_mission = NULL;
+    cmission->p_mission = cp_mission;
+
+    item_t *preward_item = item_new("parent rewards", "rewards", "reward items");
+    item_t *creward_item = item_new("child rewards", "rewards", "rewards for child");
+    reward_t *preward = reward_new(30, preward_item);
+    reward_t *creward = reward_new(20, creward_item);
+    prereq_t *p_prereq = prereq_new(20, 30);
+    prereq_t *c_prereq = prereq_new(10, 60);
+
+    item_t *item = item_new("test item", "item for testing", "item");
+    reward_t *reward = reward_new(20, item);
+    prereq_t *prereq = prereq_new(50, 50);
+    task_tree_t *task_tree = NULL;
+    quest_t *quest = quest_new("quest", task_tree, reward, prereq);
+
+    task_t *parent_task = task_new(pmission, "parent task", preward, p_prereq);
+    task_t *child_task = task_new(cmission, "child task", creward, c_prereq);
+
+    int add_parent = add_task_to_quest(quest, parent_task, "NULL");
+    int add_child = add_task_to_quest(quest, child_task, "parent task");
+
+    int freed = task_tree_free(quest->task_tree);
+
+    cr_assert_eq(freed, SUCCESS, "task_tree_free() failed");
+}
+
+/* Tests mission_free function */
+Test(mission, free)
 {
     class_t* class = generate_test_class();
     char *npc_meet_id = "meet_npc";

--- a/tests/quests/test_quests_state.c
+++ b/tests/quests/test_quests_state.c
@@ -249,6 +249,45 @@ Test(task, free)
 	cr_assert_eq(freed, SUCCESS, "task_free() test has failed!");
 }
 
+/* Tests task_tree_free function */
+Test(task_tree, free)
+{
+    item_t *parent_item = item_new("parent test item", "item for testing",
+    "test item");
+    item_t *child_item = item_new("child test item", "item", "test item");
+    active_mission_t *pa_mission = active_mission_new(parent_item, NULL, NULL, NULL);
+    mission_t *pmission = malloc(sizeof(mission_t));
+    pmission->a_mission = pa_mission;
+    pmission->p_mission = NULL;
+    mission_t *cmission = malloc(sizeof(mission_t));
+    passive_mission_t *cp_mission = passive_mission_new(3, 50, 40);
+    cmission->a_mission = NULL;
+    cmission->p_mission = cp_mission;
+
+    item_t *preward_item = item_new("parent rewards", "rewards", "reward items");
+    item_t *creward_item = item_new("child rewards", "rewards", "rewards for child");
+    reward_t *preward = reward_new(30, preward_item);
+    reward_t *creward = reward_new(20, creward_item);
+    prereq_t *p_prereq = prereq_new(20, 30);
+    prereq_t *c_prereq = prereq_new(10, 60);
+
+    item_t *item = item_new("test item", "item for testing", "item");
+    reward_t *reward = reward_new(20, item);
+    prereq_t *prereq = prereq_new(50, 50);
+    task_tree_t *task_tree = NULL;
+    quest_t *quest = quest_new("quest", task_tree, reward, prereq);
+
+    task_t *parent_task = task_new(pmission, "parent task", preward, p_prereq);
+    task_t *child_task = task_new(cmission, "child task", creward, c_prereq);
+
+    int add_parent = add_task_to_quest(quest, parent_task, "NULL");
+    int add_child = add_task_to_quest(quest, child_task, "parent task");
+
+    int freed = task_tree_free(quest->task_tree);
+
+    cr_assert_eq(freed, SUCCESS, "task_tree_free() failed");
+}
+
 /* Tests passive_mission_free function */
 Test(active_mission, free)
 {


### PR DESCRIPTION
Previously task tree wasn't allocated properly which was causing tests in other branches to fail. There was also no function to free the task trees at all. We have fixed the function that adds tasks to a tree by using the new find_task_in_tree function and revisited how trees are supposed to work.  We also wrote the function to free the trees and wrote a test for it